### PR TITLE
Updated elastic-transport dependency settings.  

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
     "index",
 ]
 dependencies = [
-    "elastic-transport>=8,<9",
+    "elastic-transport>=8.4.1,<9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
8.1.2 does not contain the argument 'use_default_ports_for_scheme' in the source definition of  url_to_node_config.
client_utils.py