### PR TITLE
Allow unrestricted body again

### DIFF
--- a/elasticsearch_serverless/_async/client/async_search.py
+++ b/elasticsearch_serverless/_async/client/async_search.py
@@ -156,7 +156,41 @@ class AsyncSearchClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -261,6 +295,7 @@ class AsyncSearchClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a search request asynchronously.
@@ -397,8 +432,8 @@ class AsyncSearchClient(NamespacedClient):
             __path = f"/{_quote(index)}/_async_search"
         else:
             __path = "/_async_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -410,10 +445,6 @@ class AsyncSearchClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -426,106 +457,54 @@ class AsyncSearchClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -534,20 +513,77 @@ class AsyncSearchClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_completion_timeout is not None:
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_async/client/enrich.py
+++ b/elasticsearch_serverless/_async/client/enrich.py
@@ -135,7 +135,7 @@ class EnrichClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("geo_match", "match", "range"),
     )
     async def put_policy(
         self,
@@ -148,6 +148,7 @@ class EnrichClient(NamespacedClient):
         match: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         range: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new enrich policy.
@@ -165,21 +166,22 @@ class EnrichClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_enrich/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if geo_match is not None:
-            __body["geo_match"] = geo_match
         if human is not None:
             __query["human"] = human
-        if match is not None:
-            __body["match"] = match
         if pretty is not None:
             __query["pretty"] = pretty
-        if range is not None:
-            __body["range"] = range
+        if not __body:
+            if geo_match is not None:
+                __body["geo_match"] = geo_match
+            if match is not None:
+                __body["match"] = match
+            if range is not None:
+                __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/eql.py
+++ b/elasticsearch_serverless/_async/client/eql.py
@@ -146,13 +146,28 @@ class EqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "query",
+            "case_sensitive",
+            "event_category_field",
+            "fetch_size",
+            "fields",
+            "filter",
+            "keep_alive",
+            "keep_on_completion",
+            "result_position",
+            "runtime_mappings",
+            "size",
+            "tiebreaker_field",
+            "timestamp_field",
+            "wait_for_completion_timeout",
+        ),
     )
     async def search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        query: str,
+        query: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         case_sensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -186,6 +201,7 @@ class EqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -220,53 +236,54 @@ class EqlClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = f"/{_quote(index)}/_eql/search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if case_sensitive is not None:
-            __body["case_sensitive"] = case_sensitive
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if event_category_field is not None:
-            __body["event_category_field"] = event_category_field
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
         if pretty is not None:
             __query["pretty"] = pretty
-        if result_position is not None:
-            __body["result_position"] = result_position
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if tiebreaker_field is not None:
-            __body["tiebreaker_field"] = tiebreaker_field
-        if timestamp_field is not None:
-            __body["timestamp_field"] = timestamp_field
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if case_sensitive is not None:
+                __body["case_sensitive"] = case_sensitive
+            if event_category_field is not None:
+                __body["event_category_field"] = event_category_field
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if result_position is not None:
+                __body["result_position"] = result_position
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if tiebreaker_field is not None:
+                __body["tiebreaker_field"] = tiebreaker_field
+            if timestamp_field is not None:
+                __body["timestamp_field"] = timestamp_field
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/graph.py
+++ b/elasticsearch_serverless/_async/client/graph.py
@@ -26,7 +26,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class GraphClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("connections", "controls", "query", "vertices"),
     )
     async def explore(
         self,
@@ -42,6 +42,7 @@ class GraphClient(NamespacedClient):
         routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         vertices: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explore extracted and summarized information about the documents and terms in
@@ -65,12 +66,8 @@ class GraphClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_graph/explore"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if connections is not None:
-            __body["connections"] = connections
-        if controls is not None:
-            __body["controls"] = controls
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -79,14 +76,19 @@ class GraphClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if timeout is not None:
             __query["timeout"] = timeout
-        if vertices is not None:
-            __body["vertices"] = vertices
+        if not __body:
+            if connections is not None:
+                __body["connections"] = connections
+            if controls is not None:
+                __body["controls"] = controls
+            if query is not None:
+                __body["query"] = query
+            if vertices is not None:
+                __body["vertices"] = vertices
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_async/client/indices.py
+++ b/elasticsearch_serverless/_async/client/indices.py
@@ -97,7 +97,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analyzer",
+            "attributes",
+            "char_filter",
+            "explain",
+            "field",
+            "filter",
+            "normalizer",
+            "text",
+            "tokenizer",
+        ),
     )
     async def analyze(
         self,
@@ -116,6 +126,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         text: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         tokenizer: t.Optional[t.Union[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -148,34 +159,35 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(index)}/_analyze"
         else:
             __path = "/_analyze"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analyzer is not None:
-            __body["analyzer"] = analyzer
-        if attributes is not None:
-            __body["attributes"] = attributes
-        if char_filter is not None:
-            __body["char_filter"] = char_filter
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if explain is not None:
-            __body["explain"] = explain
-        if field is not None:
-            __body["field"] = field
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if normalizer is not None:
-            __body["normalizer"] = normalizer
         if pretty is not None:
             __query["pretty"] = pretty
-        if text is not None:
-            __body["text"] = text
-        if tokenizer is not None:
-            __body["tokenizer"] = tokenizer
+        if not __body:
+            if analyzer is not None:
+                __body["analyzer"] = analyzer
+            if attributes is not None:
+                __body["attributes"] = attributes
+            if char_filter is not None:
+                __body["char_filter"] = char_filter
+            if explain is not None:
+                __body["explain"] = explain
+            if field is not None:
+                __body["field"] = field
+            if filter is not None:
+                __body["filter"] = filter
+            if normalizer is not None:
+                __body["normalizer"] = normalizer
+            if text is not None:
+                __body["text"] = text
+            if tokenizer is not None:
+                __body["tokenizer"] = tokenizer
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -186,7 +198,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "mappings", "settings"),
     )
     async def create(
         self,
@@ -206,6 +218,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an index with optional settings and mappings.
@@ -229,28 +242,29 @@ class IndicesClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1398,16 +1412,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     async def modify_data_stream(
         self,
         *,
-        actions: t.Sequence[t.Mapping[str, t.Any]],
+        actions: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Modifies a data stream
@@ -1416,13 +1431,11 @@ class IndicesClient(NamespacedClient):
 
         :param actions: Actions to perform.
         """
-        if actions is None:
+        if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
         __path = "/_data_stream/_modify"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1431,13 +1444,22 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "filter",
+            "index_routing",
+            "is_write_index",
+            "routing",
+            "search_routing",
+        ),
     )
     async def put_alias(
         self,
@@ -1457,6 +1479,7 @@ class IndicesClient(NamespacedClient):
         routing: t.Optional[str] = None,
         search_routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an alias.
@@ -1495,29 +1518,30 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/{_quote(index)}/_alias/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_routing is not None:
-            __body["index_routing"] = index_routing
-        if is_write_index is not None:
-            __body["is_write_index"] = is_write_index
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if routing is not None:
-            __body["routing"] = routing
-        if search_routing is not None:
-            __body["search_routing"] = search_routing
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if filter is not None:
+                __body["filter"] = filter
+            if index_routing is not None:
+                __body["index_routing"] = index_routing
+            if is_write_index is not None:
+                __body["is_write_index"] = is_write_index
+            if routing is not None:
+                __body["routing"] = routing
+            if search_routing is not None:
+                __body["search_routing"] = search_routing
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1528,7 +1552,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data_retention", "downsampling"),
     )
     async def put_data_lifecycle(
         self,
@@ -1554,6 +1578,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the data stream lifecycle of the selected data streams.
@@ -1581,12 +1606,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_data_stream/{_quote(name)}/_lifecycle"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data_retention is not None:
-            __body["data_retention"] = data_retention
-        if downsampling is not None:
-            __body["downsampling"] = downsampling
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -1602,6 +1623,11 @@ class IndicesClient(NamespacedClient):
         if timeout is not None:
             __query["timeout"] = timeout
         if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -1611,7 +1637,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_index_template(
@@ -1630,6 +1664,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -1661,39 +1696,52 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "date_detection",
+            "dynamic",
+            "dynamic_date_formats",
+            "dynamic_templates",
+            "field_names",
+            "meta",
+            "numeric_detection",
+            "properties",
+            "routing",
+            "runtime",
+            "source",
+        ),
         parameter_aliases={
             "_field_names": "field_names",
             "_meta": "meta",
@@ -1742,6 +1790,7 @@ class IndicesClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         write_index_only: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the index mappings.
@@ -1788,23 +1837,13 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_mapping"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if date_detection is not None:
-            __body["date_detection"] = date_detection
-        if dynamic is not None:
-            __body["dynamic"] = dynamic
-        if dynamic_date_formats is not None:
-            __body["dynamic_date_formats"] = dynamic_date_formats
-        if dynamic_templates is not None:
-            __body["dynamic_templates"] = dynamic_templates
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if field_names is not None:
-            __body["_field_names"] = field_names
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -1813,24 +1852,35 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if numeric_detection is not None:
-            __body["numeric_detection"] = numeric_detection
         if pretty is not None:
             __query["pretty"] = pretty
-        if properties is not None:
-            __body["properties"] = properties
-        if routing is not None:
-            __body["_routing"] = routing
-        if runtime is not None:
-            __body["runtime"] = runtime
-        if source is not None:
-            __body["_source"] = source
         if timeout is not None:
             __query["timeout"] = timeout
         if write_index_only is not None:
             __query["write_index_only"] = write_index_only
+        if not __body:
+            if date_detection is not None:
+                __body["date_detection"] = date_detection
+            if dynamic is not None:
+                __body["dynamic"] = dynamic
+            if dynamic_date_formats is not None:
+                __body["dynamic_date_formats"] = dynamic_date_formats
+            if dynamic_templates is not None:
+                __body["dynamic_templates"] = dynamic_templates
+            if field_names is not None:
+                __body["_field_names"] = field_names
+            if meta is not None:
+                __body["_meta"] = meta
+            if numeric_detection is not None:
+                __body["numeric_detection"] = numeric_detection
+            if properties is not None:
+                __body["properties"] = properties
+            if routing is not None:
+                __body["_routing"] = routing
+            if runtime is not None:
+                __body["runtime"] = runtime
+            if source is not None:
+                __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1842,7 +1892,8 @@ class IndicesClient(NamespacedClient):
     async def put_settings(
         self,
         *,
-        settings: t.Mapping[str, t.Any],
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -1892,8 +1943,12 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
-        if settings is None:
-            raise ValueError("Empty value passed for parameter 'settings'")
+        if settings is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'settings' and 'body', one of them should be set."
+            )
+        elif settings is not None and body is not None:
+            raise ValueError("Cannot set both 'settings' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings"
         else:
@@ -1921,14 +1976,21 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = settings
+        __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aliases",
+            "index_patterns",
+            "mappings",
+            "order",
+            "settings",
+            "version",
+        ),
     )
     async def put_template(
         self,
@@ -1950,6 +2012,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -1980,10 +2043,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -1994,22 +2055,25 @@ class IndicesClient(NamespacedClient):
             __query["flat_settings"] = flat_settings
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if order is not None:
-            __body["order"] = order
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if order is not None:
+                __body["order"] = order
+            if settings is not None:
+                __body["settings"] = settings
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2128,7 +2192,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "conditions", "mappings", "settings"),
     )
     async def rollover(
         self,
@@ -2151,6 +2215,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates an alias to point to a new index when the existing index is considered
@@ -2192,12 +2257,8 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(alias)}/_rollover"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
-        if conditions is not None:
-            __body["conditions"] = conditions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -2206,18 +2267,23 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if conditions is not None:
+                __body["conditions"] = conditions
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2275,7 +2341,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_auto_create",
+            "composed_of",
+            "data_stream",
+            "ignore_missing_component_templates",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def simulate_template(
@@ -2300,6 +2376,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate resolving the given template name or body
@@ -2351,42 +2428,43 @@ class IndicesClient(NamespacedClient):
             __path = f"/_index_template/_simulate/{_quote(name)}"
         else:
             __path = "/_index_template/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_missing_component_templates is not None:
-            __body["ignore_missing_component_templates"] = (
-                ignore_missing_component_templates
-            )
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if ignore_missing_component_templates is not None:
+                __body["ignore_missing_component_templates"] = (
+                    ignore_missing_component_templates
+                )
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2397,7 +2475,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     async def update_aliases(
         self,
@@ -2411,6 +2489,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates index aliases.
@@ -2425,10 +2504,8 @@ class IndicesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2441,13 +2518,16 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     async def validate_query(
         self,
@@ -2477,6 +2557,7 @@ class IndicesClient(NamespacedClient):
         q: t.Optional[str] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         rewrite: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows a user to validate a potentially expensive query without executing it.
@@ -2519,7 +2600,7 @@ class IndicesClient(NamespacedClient):
         else:
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if all_shards is not None:
             __query["all_shards"] = all_shards
         if allow_no_indices is not None:
@@ -2550,10 +2631,11 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if rewrite is not None:
             __query["rewrite"] = rewrite
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_async/client/ingest.py
+++ b/elasticsearch_serverless/_async/client/ingest.py
@@ -151,7 +151,7 @@ class IngestClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "meta", "on_failure", "processors", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_pipeline(
@@ -172,6 +172,7 @@ class IngestClient(NamespacedClient):
         processors: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a pipeline.
@@ -204,10 +205,8 @@ class IngestClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ingest/pipeline/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -218,25 +217,28 @@ class IngestClient(NamespacedClient):
             __query["if_version"] = if_version
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if on_failure is not None:
-            __body["on_failure"] = on_failure
         if pretty is not None:
             __query["pretty"] = pretty
-        if processors is not None:
-            __body["processors"] = processors
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if meta is not None:
+                __body["_meta"] = meta
+            if on_failure is not None:
+                __body["on_failure"] = on_failure
+            if processors is not None:
+                __body["processors"] = processors
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "pipeline"),
     )
     async def simulate(
         self,
@@ -249,6 +251,7 @@ class IngestClient(NamespacedClient):
         pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         verbose: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to simulate a pipeline with example documents.
@@ -268,22 +271,23 @@ class IngestClient(NamespacedClient):
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
         else:
             __path = "/_ingest/pipeline/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if pipeline is not None:
-            __body["pipeline"] = pipeline
         if pretty is not None:
             __query["pretty"] = pretty
         if verbose is not None:
             __query["verbose"] = verbose
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if pipeline is not None:
+                __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/logstash.py
+++ b/elasticsearch_serverless/_async/client/logstash.py
@@ -101,7 +101,8 @@ class LogstashClient(NamespacedClient):
         self,
         *,
         id: str,
-        pipeline: t.Mapping[str, t.Any],
+        pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -117,8 +118,12 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if pipeline is None:
-            raise ValueError("Empty value passed for parameter 'pipeline'")
+        if pipeline is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'pipeline' and 'body', one of them should be set."
+            )
+        elif pipeline is not None and body is not None:
+            raise ValueError("Cannot set both 'pipeline' and 'body'")
         __path = f"/_logstash/pipeline/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -129,7 +134,7 @@ class LogstashClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = pipeline
+        __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/ml.py
+++ b/elasticsearch_serverless/_async/client/ml.py
@@ -26,7 +26,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class MlClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     async def close_job(
         self,
@@ -39,6 +39,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
@@ -59,22 +60,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -444,7 +446,11 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "max_bucket_cardinality",
+            "overall_cardinality",
+        ),
     )
     async def estimate_model_memory(
         self,
@@ -456,6 +462,7 @@ class MlClient(NamespacedClient):
         max_bucket_cardinality: t.Optional[t.Mapping[str, int]] = None,
         overall_cardinality: t.Optional[t.Mapping[str, int]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Estimates the model memory
@@ -478,40 +485,42 @@ class MlClient(NamespacedClient):
             or `partition_field_name`.
         """
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_bucket_cardinality is not None:
-            __body["max_bucket_cardinality"] = max_bucket_cardinality
-        if overall_cardinality is not None:
-            __body["overall_cardinality"] = overall_cardinality
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if max_bucket_cardinality is not None:
+                __body["max_bucket_cardinality"] = max_bucket_cardinality
+            if overall_cardinality is not None:
+                __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("evaluation", "index", "query"),
     )
     async def evaluate_data_frame(
         self,
         *,
-        evaluation: t.Mapping[str, t.Any],
-        index: str,
+        evaluation: t.Optional[t.Mapping[str, t.Any]] = None,
+        index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluates the data frame analytics for an annotated index.
@@ -523,17 +532,13 @@ class MlClient(NamespacedClient):
         :param query: A query clause that retrieves a subset of data from the source
             index.
         """
-        if evaluation is None:
+        if evaluation is None and body is None:
             raise ValueError("Empty value passed for parameter 'evaluation'")
-        if index is None:
+        if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = "/_ml/data_frame/_evaluate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if evaluation is not None:
-            __body["evaluation"] = evaluation
-        if index is not None:
-            __body["index"] = index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -542,15 +547,20 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
+        if not __body:
+            if evaluation is not None:
+                __body["evaluation"] = evaluation
+            if index is not None:
+                __body["index"] = index
+            if query is not None:
+                __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("advance_time", "calc_interim", "end", "skip_time", "start"),
     )
     async def flush_job(
         self,
@@ -565,6 +575,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         skip_time: t.Optional[t.Union[str, t.Any]] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces any buffered data to be processed by the job.
@@ -581,14 +592,8 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if advance_time is not None:
-            __body["advance_time"] = advance_time
-        if calc_interim is not None:
-            __body["calc_interim"] = calc_interim
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -597,10 +602,17 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if skip_time is not None:
-            __body["skip_time"] = skip_time
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if advance_time is not None:
+                __body["advance_time"] = advance_time
+            if calc_interim is not None:
+                __body["calc_interim"] = calc_interim
+            if end is not None:
+                __body["end"] = end
+            if skip_time is not None:
+                __body["skip_time"] = skip_time
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -671,7 +683,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     async def get_calendars(
@@ -685,6 +697,7 @@ class MlClient(NamespacedClient):
         page: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves configuration information for calendars.
@@ -706,7 +719,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -715,12 +728,13 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1103,7 +1117,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_no_match",
+            "bucket_span",
+            "end",
+            "exclude_interim",
+            "overall_score",
+            "start",
+            "top_n",
+        ),
     )
     async def get_overall_buckets(
         self,
@@ -1120,6 +1142,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         top_n: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
@@ -1145,30 +1168,31 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
-        if bucket_span is not None:
-            __body["bucket_span"] = bucket_span
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if overall_score is not None:
-            __body["overall_score"] = overall_score
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if top_n is not None:
-            __body["top_n"] = top_n
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if bucket_span is not None:
+                __body["bucket_span"] = bucket_span
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if overall_score is not None:
+                __body["overall_score"] = overall_score
+            if start is not None:
+                __body["start"] = start
+            if top_n is not None:
+                __body["top_n"] = top_n
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1314,19 +1338,20 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "inference_config"),
     )
     async def infer_trained_model(
         self,
         *,
         model_id: str,
-        docs: t.Sequence[t.Mapping[str, t.Any]],
+        docs: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluate a trained model.
@@ -1344,32 +1369,33 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if docs is None:
+        if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("timeout",),
     )
     async def open_job(
         self,
@@ -1380,6 +1406,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Opens one or more anomaly detection jobs.
@@ -1393,7 +1420,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1402,8 +1429,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1414,17 +1442,18 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("events",),
     )
     async def post_calendar_events(
         self,
         *,
         calendar_id: str,
-        events: t.Sequence[t.Mapping[str, t.Any]],
+        events: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Posts scheduled events in a calendar.
@@ -1438,13 +1467,11 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        if events is None:
+        if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if events is not None:
-            __body["events"] = events
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1453,13 +1480,16 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if events is not None:
+                __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config",),
     )
     async def preview_data_frame_analytics(
         self,
@@ -1470,6 +1500,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews that will be analyzed given a data frame analytics config.
@@ -1485,10 +1516,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
         else:
             __path = "/_ml/data_frame/analytics/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1497,6 +1526,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if config is not None:
+                __body["config"] = config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1507,7 +1539,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("datafeed_config", "job_config"),
     )
     async def preview_datafeed(
         self,
@@ -1521,6 +1553,7 @@ class MlClient(NamespacedClient):
         job_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a datafeed.
@@ -1546,10 +1579,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
         else:
             __path = "/_ml/datafeeds/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if end is not None:
             __query["end"] = end
         if error_trace is not None:
@@ -1558,12 +1589,15 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_config is not None:
-            __body["job_config"] = job_config
         if pretty is not None:
             __query["pretty"] = pretty
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if job_config is not None:
+                __body["job_config"] = job_config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1574,7 +1608,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "job_ids"),
     )
     async def put_calendar(
         self,
@@ -1586,6 +1620,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         job_ids: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a calendar.
@@ -1599,20 +1634,21 @@ class MlClient(NamespacedClient):
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_ids is not None:
-            __body["job_ids"] = job_ids
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if job_ids is not None:
+                __body["job_ids"] = job_ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1662,16 +1698,27 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis",
+            "dest",
+            "source",
+            "allow_lazy_start",
+            "analyzed_fields",
+            "description",
+            "headers",
+            "max_num_threads",
+            "model_memory_limit",
+            "version",
+        ),
         ignore_deprecated_options={"headers"},
     )
     async def put_data_frame_analytics(
         self,
         *,
         id: str,
-        analysis: t.Mapping[str, t.Any],
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        analysis: t.Optional[t.Mapping[str, t.Any]] = None,
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_start: t.Optional[bool] = None,
         analyzed_fields: t.Optional[t.Mapping[str, t.Any]] = None,
         description: t.Optional[str] = None,
@@ -1683,6 +1730,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a data frame analytics job.
@@ -1746,50 +1794,67 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if analysis is None:
+        if analysis is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if headers is not None:
+                __body["headers"] = headers
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "headers",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
         ignore_deprecated_options={"headers"},
     )
     async def put_datafeed(
@@ -1826,6 +1891,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a datafeed.
@@ -1904,61 +1970,62 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if headers is not None:
+                __body["headers"] = headers
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "items"),
     )
     async def put_filter(
         self,
@@ -1970,6 +2037,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         items: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a filter.
@@ -1984,34 +2052,51 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if items is not None:
-            __body["items"] = items
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if items is not None:
+                __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "data_description",
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "datafeed_config",
+            "description",
+            "groups",
+            "model_plot_config",
+            "model_snapshot_retention_days",
+            "renormalization_window_days",
+            "results_index_name",
+            "results_retention_days",
+        ),
     )
     async def put_job(
         self,
         *,
         job_id: str,
-        analysis_config: t.Mapping[str, t.Any],
-        data_description: t.Mapping[str, t.Any],
+        analysis_config: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_description: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_open: t.Optional[bool] = None,
         analysis_limits: t.Optional[t.Mapping[str, t.Any]] = None,
         background_persist_interval: t.Optional[
@@ -2031,6 +2116,7 @@ class MlClient(NamespacedClient):
         renormalization_window_days: t.Optional[int] = None,
         results_index_name: t.Optional[str] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates an anomaly detection job.
@@ -2112,60 +2198,73 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if analysis_config is None:
+        if analysis_config is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis_config'")
-        if data_description is None:
+        if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body["daily_model_snapshot_retention_after_days"] = (
-                daily_model_snapshot_retention_after_days
-            )
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body["daily_model_snapshot_retention_after_days"] = (
+                    daily_model_snapshot_retention_after_days
+                )
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if description is not None:
+                __body["description"] = description
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "compressed_definition",
+            "definition",
+            "description",
+            "inference_config",
+            "input",
+            "metadata",
+            "model_size_bytes",
+            "model_type",
+            "platform_architecture",
+            "prefix_strings",
+            "tags",
+        ),
     )
     async def put_trained_model(
         self,
@@ -2190,6 +2289,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         tags: t.Optional[t.Sequence[str]] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an inference trained model.
@@ -2232,42 +2332,43 @@ class MlClient(NamespacedClient):
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if compressed_definition is not None:
-            __body["compressed_definition"] = compressed_definition
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
             __query["defer_definition_decompression"] = defer_definition_decompression
-        if definition is not None:
-            __body["definition"] = definition
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if model_size_bytes is not None:
-            __body["model_size_bytes"] = model_size_bytes
-        if model_type is not None:
-            __body["model_type"] = model_type
-        if platform_architecture is not None:
-            __body["platform_architecture"] = platform_architecture
-        if prefix_strings is not None:
-            __body["prefix_strings"] = prefix_strings
         if pretty is not None:
             __query["pretty"] = pretty
-        if tags is not None:
-            __body["tags"] = tags
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if compressed_definition is not None:
+                __body["compressed_definition"] = compressed_definition
+            if definition is not None:
+                __body["definition"] = definition
+            if description is not None:
+                __body["description"] = description
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if model_size_bytes is not None:
+                __body["model_size_bytes"] = model_size_bytes
+            if model_type is not None:
+                __body["model_type"] = model_type
+            if platform_architecture is not None:
+                __body["platform_architecture"] = platform_architecture
+            if prefix_strings is not None:
+                __body["prefix_strings"] = prefix_strings
+            if tags is not None:
+                __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2319,20 +2420,21 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("definition", "total_definition_length", "total_parts"),
     )
     async def put_trained_model_definition_part(
         self,
         *,
         model_id: str,
         part: int,
-        definition: str,
-        total_definition_length: int,
-        total_parts: int,
+        definition: t.Optional[str] = None,
+        total_definition_length: t.Optional[int] = None,
+        total_parts: t.Optional[int] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates part of a trained model definition
@@ -2354,23 +2456,17 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if part in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'part'")
-        if definition is None:
+        if definition is None and body is None:
             raise ValueError("Empty value passed for parameter 'definition'")
-        if total_definition_length is None:
+        if total_definition_length is None and body is None:
             raise ValueError(
                 "Empty value passed for parameter 'total_definition_length'"
             )
-        if total_parts is None:
+        if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if definition is not None:
-            __body["definition"] = definition
-        if total_definition_length is not None:
-            __body["total_definition_length"] = total_definition_length
-        if total_parts is not None:
-            __body["total_parts"] = total_parts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2379,25 +2475,33 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if definition is not None:
+                __body["definition"] = definition
+            if total_definition_length is not None:
+                __body["total_definition_length"] = total_definition_length
+            if total_parts is not None:
+                __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("vocabulary", "merges", "scores"),
     )
     async def put_trained_model_vocabulary(
         self,
         *,
         model_id: str,
-        vocabulary: t.Sequence[str],
+        vocabulary: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
         scores: t.Optional[t.Sequence[float]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a trained model vocabulary
@@ -2411,25 +2515,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if vocabulary is None:
+        if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if vocabulary is not None:
-            __body["vocabulary"] = vocabulary
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if merges is not None:
-            __body["merges"] = merges
         if pretty is not None:
             __query["pretty"] = pretty
-        if scores is not None:
-            __body["scores"] = scores
+        if not __body:
+            if vocabulary is not None:
+                __body["vocabulary"] = vocabulary
+            if merges is not None:
+                __body["merges"] = merges
+            if scores is not None:
+                __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2522,7 +2627,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("end", "start", "timeout"),
     )
     async def start_datafeed(
         self,
@@ -2535,6 +2640,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Starts one or more datafeeds.
@@ -2552,10 +2658,8 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2564,10 +2668,13 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if end is not None:
+                __body["end"] = end
+            if start is not None:
+                __body["start"] = start
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2718,7 +2825,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     async def stop_datafeed(
         self,
@@ -2731,6 +2838,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Stops one or more datafeeds.
@@ -2749,22 +2857,23 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2824,7 +2933,12 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "description",
+            "max_num_threads",
+            "model_memory_limit",
+        ),
     )
     async def update_data_frame_analytics(
         self,
@@ -2838,6 +2952,7 @@ class MlClient(NamespacedClient):
         max_num_threads: t.Optional[int] = None,
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a data frame analytics job.
@@ -2863,31 +2978,47 @@ class MlClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if description is not None:
+                __body["description"] = description
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
     )
     async def update_datafeed(
         self,
@@ -2922,6 +3053,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a datafeed.
@@ -3011,59 +3143,60 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("add_items", "description", "remove_items"),
     )
     async def update_filter(
         self,
@@ -3076,6 +3209,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         remove_items: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the description of a filter, adds items, or removes items.
@@ -3090,12 +3224,8 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if add_items is not None:
-            __body["add_items"] = add_items
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3104,15 +3234,36 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if remove_items is not None:
-            __body["remove_items"] = remove_items
+        if not __body:
+            if add_items is not None:
+                __body["add_items"] = add_items
+            if description is not None:
+                __body["description"] = description
+            if remove_items is not None:
+                __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "categorization_filters",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "description",
+            "detectors",
+            "groups",
+            "model_plot_config",
+            "model_prune_window",
+            "model_snapshot_retention_days",
+            "per_partition_categorization",
+            "renormalization_window_days",
+            "results_retention_days",
+        ),
     )
     async def update_job(
         self,
@@ -3141,6 +3292,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         renormalization_window_days: t.Optional[int] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of an anomaly detection job.
@@ -3199,48 +3351,49 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if categorization_filters is not None:
-            __body["categorization_filters"] = categorization_filters
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body["daily_model_snapshot_retention_after_days"] = (
-                daily_model_snapshot_retention_after_days
-            )
-        if description is not None:
-            __body["description"] = description
-        if detectors is not None:
-            __body["detectors"] = detectors
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_prune_window is not None:
-            __body["model_prune_window"] = model_prune_window
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
-        if per_partition_categorization is not None:
-            __body["per_partition_categorization"] = per_partition_categorization
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if categorization_filters is not None:
+                __body["categorization_filters"] = categorization_filters
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body["daily_model_snapshot_retention_after_days"] = (
+                    daily_model_snapshot_retention_after_days
+                )
+            if description is not None:
+                __body["description"] = description
+            if detectors is not None:
+                __body["detectors"] = detectors
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_prune_window is not None:
+                __body["model_prune_window"] = model_prune_window
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if per_partition_categorization is not None:
+                __body["per_partition_categorization"] = per_partition_categorization
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/query_ruleset.py
+++ b/elasticsearch_serverless/_async/client/query_ruleset.py
@@ -134,17 +134,18 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("rules",),
     )
     async def put(
         self,
         *,
         ruleset_id: str,
-        rules: t.Sequence[t.Mapping[str, t.Any]],
+        rules: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a query ruleset.
@@ -157,13 +158,11 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if rules is None:
+        if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if rules is not None:
-            __body["rules"] = rules
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -172,6 +171,9 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if rules is not None:
+                __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/search_application.py
+++ b/elasticsearch_serverless/_async/client/search_application.py
@@ -213,7 +213,8 @@ class SearchApplicationClient(NamespacedClient):
         self,
         *,
         name: str,
-        search_application: t.Mapping[str, t.Any],
+        search_application: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -232,8 +233,12 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
+        if search_application is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_application' and 'body', one of them should be set."
+            )
+        elif search_application is not None and body is not None:
+            raise ValueError("Cannot set both 'search_application' and 'body'")
         __path = f"/_application/search_application/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -246,7 +251,7 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = search_application
+        __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -287,7 +292,7 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("params",),
         ignore_deprecated_options={"params"},
     )
     async def search(
@@ -299,6 +304,7 @@ class SearchApplicationClient(NamespacedClient):
         human: t.Optional[bool] = None,
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Perform a search against a search application
@@ -313,17 +319,18 @@ class SearchApplicationClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_application/search_application/{_quote(name)}/_search"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if params is not None:
+                __body["params"] = params
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_async/client/security.py
+++ b/elasticsearch_serverless/_async/client/security.py
@@ -56,7 +56,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "name", "role_descriptors"),
     )
     async def create_api_key(
         self,
@@ -72,6 +72,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key for access without requiring basic authentication.
@@ -98,25 +99,26 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if name is not None:
+                __body["name"] = name
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -199,7 +201,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("application", "cluster", "index"),
     )
     async def has_privileges(
         self,
@@ -219,6 +221,7 @@ class SecurityClient(NamespacedClient):
         human: t.Optional[bool] = None,
         index: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the specified user has a specified list of privileges.
@@ -234,29 +237,30 @@ class SecurityClient(NamespacedClient):
             __path = f"/_security/user/{_quote(user)}/_has_privileges"
         else:
             __path = "/_security/user/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if application is not None:
-            __body["application"] = application
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if application is not None:
+                __body["application"] = application
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if index is not None:
+                __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id", "ids", "name", "owner", "realm_name", "username"),
     )
     async def invalidate_api_key(
         self,
@@ -271,6 +275,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm_name: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more API keys.
@@ -293,34 +298,43 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
-        if ids is not None:
-            __body["ids"] = ids
-        if name is not None:
-            __body["name"] = name
-        if owner is not None:
-            __body["owner"] = owner
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if id is not None:
+                __body["id"] = id
+            if ids is not None:
+                __body["ids"] = ids
+            if name is not None:
+                __body["name"] = name
+            if owner is not None:
+                __body["owner"] = owner
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "from_",
+            "query",
+            "search_after",
+            "size",
+            "sort",
+        ),
         parameter_aliases={"from": "from_"},
     )
     async def query_api_keys(
@@ -347,6 +361,7 @@ class SecurityClient(NamespacedClient):
         typed_keys: t.Optional[bool] = None,
         with_limited_by: t.Optional[bool] = None,
         with_profile_uid: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information for API keys using a subset of query DSL
@@ -391,8 +406,8 @@ class SecurityClient(NamespacedClient):
             for the API key owner principal, if it exists.
         """
         __path = "/_security/_query/api_key"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -404,34 +419,35 @@ class SecurityClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
         if with_limited_by is not None:
             __query["with_limited_by"] = with_limited_by
         if with_profile_uid is not None:
             __query["with_profile_uid"] = with_profile_uid
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -442,7 +458,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "role_descriptors"),
     )
     async def update_api_key(
         self,
@@ -455,6 +471,7 @@ class SecurityClient(NamespacedClient):
         metadata: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates attributes of an existing API key.
@@ -479,21 +496,22 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_security/api_key/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_async/client/sql.py
+++ b/elasticsearch_serverless/_async/client/sql.py
@@ -26,16 +26,17 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class SqlClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("cursor",),
     )
     async def clear_cursor(
         self,
         *,
-        cursor: str,
+        cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clears the SQL cursor
@@ -44,13 +45,11 @@ class SqlClient(NamespacedClient):
 
         :param cursor: Cursor to clear.
         """
-        if cursor is None:
+        if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
         __path = "/_sql/close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -59,6 +58,9 @@ class SqlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if cursor is not None:
+                __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -193,7 +195,24 @@ class SqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "catalog",
+            "columnar",
+            "cursor",
+            "fetch_size",
+            "field_multi_value_leniency",
+            "filter",
+            "index_using_frozen",
+            "keep_alive",
+            "keep_on_completion",
+            "page_timeout",
+            "params",
+            "query",
+            "request_timeout",
+            "runtime_mappings",
+            "time_zone",
+            "wait_for_completion_timeout",
+        ),
         ignore_deprecated_options={"params", "request_timeout"},
     )
     async def query(
@@ -224,6 +243,7 @@ class SqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
@@ -262,62 +282,63 @@ class SqlClient(NamespacedClient):
             the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if catalog is not None:
-            __body["catalog"] = catalog
-        if columnar is not None:
-            __body["columnar"] = columnar
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if field_multi_value_leniency is not None:
-            __body["field_multi_value_leniency"] = field_multi_value_leniency
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if format is not None:
             __query["format"] = format
         if human is not None:
             __query["human"] = human
-        if index_using_frozen is not None:
-            __body["index_using_frozen"] = index_using_frozen
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
-        if page_timeout is not None:
-            __body["page_timeout"] = page_timeout
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if request_timeout is not None:
-            __body["request_timeout"] = request_timeout
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if catalog is not None:
+                __body["catalog"] = catalog
+            if columnar is not None:
+                __body["columnar"] = columnar
+            if cursor is not None:
+                __body["cursor"] = cursor
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if field_multi_value_leniency is not None:
+                __body["field_multi_value_leniency"] = field_multi_value_leniency
+            if filter is not None:
+                __body["filter"] = filter
+            if index_using_frozen is not None:
+                __body["index_using_frozen"] = index_using_frozen
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if page_timeout is not None:
+                __body["page_timeout"] = page_timeout
+            if params is not None:
+                __body["params"] = params
+            if query is not None:
+                __body["query"] = query
+            if request_timeout is not None:
+                __body["request_timeout"] = request_timeout
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query", "fetch_size", "filter", "time_zone"),
     )
     async def translate(
         self,
         *,
-        query: str,
+        query: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         fetch_size: t.Optional[int] = None,
         filter: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -325,6 +346,7 @@ class SqlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         time_zone: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Translates SQL into Elasticsearch queries
@@ -336,27 +358,28 @@ class SqlClient(NamespacedClient):
         :param filter: Elasticsearch query DSL for additional filtering.
         :param time_zone: ISO-8601 time zone ID for the search.
         """
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = "/_sql/translate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if filter is not None:
+                __body["filter"] = filter
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/synonyms.py
+++ b/elasticsearch_serverless/_async/client/synonyms.py
@@ -220,17 +220,18 @@ class SynonymsClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms_set",),
     )
     async def put_synonym(
         self,
         *,
         id: str,
-        synonyms_set: t.Sequence[t.Mapping[str, t.Any]],
+        synonyms_set: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonyms set
@@ -242,13 +243,11 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if synonyms_set is None:
+        if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
         __path = f"/_synonyms/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms_set is not None:
-            __body["synonyms_set"] = synonyms_set
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -257,24 +256,28 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms_set is not None:
+                __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms",),
     )
     async def put_synonym_rule(
         self,
         *,
         set_id: str,
         rule_id: str,
-        synonyms: str,
+        synonyms: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonym rule in a synonym set
@@ -289,13 +292,11 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        if synonyms is None:
+        if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
         __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms is not None:
-            __body["synonyms"] = synonyms
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -304,6 +305,9 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms is not None:
+                __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/client/transform.py
+++ b/elasticsearch_serverless/_async/client/transform.py
@@ -196,7 +196,17 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "latest",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
     )
     async def preview_transform(
         self,
@@ -216,6 +226,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a transform.
@@ -248,36 +259,37 @@ class TransformClient(NamespacedClient):
             __path = f"/_transform/{_quote(transform_id)}/_preview"
         else:
             __path = "/_transform/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -288,15 +300,26 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "dest",
+            "source",
+            "description",
+            "frequency",
+            "latest",
+            "meta",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def put_transform(
         self,
         *,
         transform_id: str,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         defer_validation: t.Optional[bool] = None,
         description: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -311,6 +334,7 @@ class TransformClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a transform.
@@ -349,45 +373,46 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_transform/{_quote(transform_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if meta is not None:
-            __body["_meta"] = meta
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if description is not None:
+                __body["description"] = description
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if meta is not None:
+                __body["_meta"] = meta
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -590,7 +615,16 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "meta",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     async def update_transform(
@@ -611,6 +645,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a transform.
@@ -640,35 +675,36 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'transform_id'")
         __path = f"/_transform/{_quote(transform_id)}/_update"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if meta is not None:
+                __body["_meta"] = meta
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return await self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_async/helpers.py
+++ b/elasticsearch_serverless/_async/helpers.py
@@ -445,7 +445,7 @@ async def async_scan(
         search_kwargs = kwargs.copy()
         search_kwargs["scroll"] = scroll
         search_kwargs["size"] = size
-        resp = await client.search(body=query, **search_kwargs)  # type: ignore[call-arg]
+        resp = await client.search(body=query, **search_kwargs)
 
     scroll_id: Optional[str] = resp.get("_scroll_id")
     scroll_transport_kwargs = pop_transport_kwargs(scroll_kwargs)

--- a/elasticsearch_serverless/_sync/client/__init__.py
+++ b/elasticsearch_serverless/_sync/client/__init__.py
@@ -442,7 +442,8 @@ class Elasticsearch(BaseClient):
     def bulk(
         self,
         *,
-        operations: t.Sequence[t.Mapping[str, t.Any]],
+        operations: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -493,8 +494,12 @@ class Elasticsearch(BaseClient):
             before proceeding with the operation. Set to all or any positive integer
             up to the total number of shards in the index (`number_of_replicas+1`).
         """
-        if operations is None:
-            raise ValueError("Empty value passed for parameter 'operations'")
+        if operations is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'operations' and 'body', one of them should be set."
+            )
+        elif operations is not None and body is not None:
+            raise ValueError("Cannot set both 'operations' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_bulk"
         else:
@@ -526,7 +531,7 @@ class Elasticsearch(BaseClient):
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = operations
+        __body = operations if operations is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -536,7 +541,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id",),
     )
     def clear_scroll(
         self,
@@ -546,6 +551,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         scroll_id: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explicitly clears the search context for a scroll.
@@ -556,7 +562,7 @@ class Elasticsearch(BaseClient):
         """
         __path = "/_search/scroll"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -565,8 +571,9 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -577,16 +584,17 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id",),
     )
     def close_point_in_time(
         self,
         *,
-        id: str,
+        id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Close a point in time
@@ -595,13 +603,11 @@ class Elasticsearch(BaseClient):
 
         :param id: The ID of the point-in-time.
         """
-        if id is None:
+        if id is None and body is None:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = "/_pit"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if id is not None:
-            __body["id"] = id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -610,6 +616,9 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if id is not None:
+                __body["id"] = id
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -620,7 +629,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     def count(
         self,
@@ -652,6 +661,7 @@ class Elasticsearch(BaseClient):
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         routing: t.Optional[str] = None,
         terminate_after: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns number of documents matching a query.
@@ -700,7 +710,7 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_count"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if analyze_wildcard is not None:
@@ -733,12 +743,13 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if terminate_after is not None:
             __query["terminate_after"] = terminate_after
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -756,7 +767,8 @@ class Elasticsearch(BaseClient):
         *,
         index: str,
         id: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -812,8 +824,12 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         __path = f"/{_quote(index)}/_create/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -838,7 +854,7 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -930,7 +946,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("max_docs", "query", "slice"),
         parameter_aliases={"from": "from_"},
     )
     def delete_by_query(
@@ -985,6 +1001,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Deletes documents matching the provided query.
@@ -1058,7 +1075,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_delete_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -1096,16 +1113,12 @@ class Elasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -1122,8 +1135,6 @@ class Elasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -1140,6 +1151,13 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if slice is not None:
+                __body["slice"] = slice
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -1379,7 +1397,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -1408,6 +1426,7 @@ class Elasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information about why a specific matches (or doesn't match) a query.
@@ -1446,7 +1465,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_explain/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if analyze_wildcard is not None:
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
@@ -1469,8 +1488,6 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if source is not None:
@@ -1482,6 +1499,9 @@ class Elasticsearch(BaseClient):
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
         if not __body:
+            if query is not None:
+                __body["query"] = query
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -1491,7 +1511,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("fields", "index_filter", "runtime_mappings"),
     )
     def field_caps(
         self,
@@ -1518,6 +1538,7 @@ class Elasticsearch(BaseClient):
         pretty: t.Optional[bool] = None,
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         types: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns the information about the capabilities of fields among multiple indices.
@@ -1557,15 +1578,13 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_field_caps"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if filters is not None:
@@ -1578,14 +1597,17 @@ class Elasticsearch(BaseClient):
             __query["include_empty_fields"] = include_empty_fields
         if include_unmapped is not None:
             __query["include_unmapped"] = include_unmapped
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
         if types is not None:
             __query["types"] = types
+        if not __body:
+            if fields is not None:
+                __body["fields"] = fields
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1837,7 +1859,8 @@ class Elasticsearch(BaseClient):
         self,
         *,
         index: str,
-        document: t.Mapping[str, t.Any],
+        document: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -1901,8 +1924,12 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if document is None:
-            raise ValueError("Empty value passed for parameter 'document'")
+        if document is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'document' and 'body', one of them should be set."
+            )
+        elif document is not None and body is not None:
+            raise ValueError("Cannot set both 'document' and 'body'")
         if index not in SKIP_IN_PATH and id not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_doc/{_quote(id)}"
             __method = "PUT"
@@ -1942,7 +1969,7 @@ class Elasticsearch(BaseClient):
             __query["version_type"] = version_type
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
-        __body = document
+        __body = document if document is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             __method, __path, params=__query, headers=__headers, body=__body
@@ -1978,7 +2005,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -2004,6 +2031,7 @@ class Elasticsearch(BaseClient):
         source_excludes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         source_includes: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         stored_fields: t.Optional[t.Union[str, t.Sequence[str]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to get multiple documents in one request.
@@ -2043,10 +2071,8 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mget"
         else:
             __path = "/_mget"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2055,8 +2081,6 @@ class Elasticsearch(BaseClient):
             __query["force_synthetic_source"] = force_synthetic_source
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
@@ -2075,6 +2099,11 @@ class Elasticsearch(BaseClient):
             __query["_source_includes"] = source_includes
         if stored_fields is not None:
             __query["stored_fields"] = stored_fields
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -2086,7 +2115,8 @@ class Elasticsearch(BaseClient):
     def msearch(
         self,
         *,
-        searches: t.Sequence[t.Mapping[str, t.Any]],
+        searches: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
@@ -2155,8 +2185,12 @@ class Elasticsearch(BaseClient):
         :param typed_keys: Specifies whether aggregation and suggester names should be
             prefixed by their respective types in the response.
         """
-        if searches is None:
-            raise ValueError("Empty value passed for parameter 'searches'")
+        if searches is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'searches' and 'body', one of them should be set."
+            )
+        elif searches is not None and body is not None:
+            raise ValueError("Cannot set both 'searches' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch"
         else:
@@ -2194,7 +2228,7 @@ class Elasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = searches
+        __body = searches if searches is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2209,7 +2243,8 @@ class Elasticsearch(BaseClient):
     def msearch_template(
         self,
         *,
-        search_templates: t.Sequence[t.Mapping[str, t.Any]],
+        search_templates: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         ccs_minimize_roundtrips: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2243,8 +2278,12 @@ class Elasticsearch(BaseClient):
         :param typed_keys: If `true`, the response prefixes aggregation and suggester
             names with their respective types.
         """
-        if search_templates is None:
-            raise ValueError("Empty value passed for parameter 'search_templates'")
+        if search_templates is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_templates' and 'body', one of them should be set."
+            )
+        elif search_templates is not None and body is not None:
+            raise ValueError("Cannot set both 'search_templates' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_msearch/template"
         else:
@@ -2268,7 +2307,7 @@ class Elasticsearch(BaseClient):
             __query["search_type"] = search_type
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        __body = search_templates
+        __body = search_templates if search_templates is not None else body
         __headers = {
             "accept": "application/json",
             "content-type": "application/x-ndjson",
@@ -2278,7 +2317,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "ids"),
     )
     def mtermvectors(
         self,
@@ -2303,6 +2342,7 @@ class Elasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns multiple termvectors in one request.
@@ -2334,10 +2374,8 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_mtermvectors"
         else:
             __path = "/_mtermvectors"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
@@ -2348,8 +2386,6 @@ class Elasticsearch(BaseClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ids is not None:
-            __body["ids"] = ids
         if offsets is not None:
             __query["offsets"] = offsets
         if payloads is not None:
@@ -2370,6 +2406,11 @@ class Elasticsearch(BaseClient):
             __query["version"] = version
         if version_type is not None:
             __query["version_type"] = version_type
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if ids is not None:
+                __body["ids"] = ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2449,13 +2490,13 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("script",),
     )
     def put_script(
         self,
         *,
         id: str,
-        script: t.Mapping[str, t.Any],
+        script: t.Optional[t.Mapping[str, t.Any]] = None,
         context: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2465,6 +2506,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a script.
@@ -2486,7 +2528,7 @@ class Elasticsearch(BaseClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if script is None:
+        if script is None and body is None:
             raise ValueError("Empty value passed for parameter 'script'")
         if id not in SKIP_IN_PATH and context not in SKIP_IN_PATH:
             __path = f"/_scripts/{_quote(id)}/{_quote(context)}"
@@ -2494,10 +2536,8 @@ class Elasticsearch(BaseClient):
             __path = f"/_scripts/{_quote(id)}"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if script is not None:
-            __body["script"] = script
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2510,18 +2550,21 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if script is not None:
+                __body["script"] = script
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("requests", "metric"),
     )
     def rank_eval(
         self,
         *,
-        requests: t.Sequence[t.Mapping[str, t.Any]],
+        requests: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -2539,6 +2582,7 @@ class Elasticsearch(BaseClient):
         metric: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         search_type: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to evaluate the quality of ranked search results over a set of typical
@@ -2564,16 +2608,14 @@ class Elasticsearch(BaseClient):
         :param metric: Definition of the evaluation metric to calculate.
         :param search_type: Search operation type
         """
-        if requests is None:
+        if requests is None and body is None:
             raise ValueError("Empty value passed for parameter 'requests'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_rank_eval"
         else:
             __path = "/_rank_eval"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if requests is not None:
-            __body["requests"] = requests
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if error_trace is not None:
@@ -2586,25 +2628,28 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if metric is not None:
-            __body["metric"] = metric
         if pretty is not None:
             __query["pretty"] = pretty
         if search_type is not None:
             __query["search_type"] = search_type
+        if not __body:
+            if requests is not None:
+                __body["requests"] = requests
+            if metric is not None:
+                __body["metric"] = metric
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("dest", "source", "conflicts", "max_docs", "script", "size"),
     )
     def reindex(
         self,
         *,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         conflicts: t.Optional[t.Union["t.Literal['abort', 'proceed']", str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -2623,6 +2668,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to copy documents from one index to another, optionally filtering the
@@ -2655,27 +2701,19 @@ class Elasticsearch(BaseClient):
         :param wait_for_completion: If `true`, the request blocks until the operation
             is complete.
         """
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = "/_reindex"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
@@ -2684,12 +2722,8 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if require_alias is not None:
             __query["require_alias"] = require_alias
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
-        if size is not None:
-            __body["size"] = size
         if slices is not None:
             __query["slices"] = slices
         if timeout is not None:
@@ -2698,13 +2732,26 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if script is not None:
+                __body["script"] = script
+            if size is not None:
+                __body["size"] = size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("file", "params", "source"),
         ignore_deprecated_options={"params"},
     )
     def render_search_template(
@@ -2718,6 +2765,7 @@ class Elasticsearch(BaseClient):
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         source: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -2738,21 +2786,22 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_render/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if file is not None:
-            __body["file"] = file
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if source is not None:
-            __body["source"] = source
+        if not __body:
+            if file is not None:
+                __body["file"] = file
+            if params is not None:
+                __body["params"] = params
+            if source is not None:
+                __body["source"] = source
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2763,7 +2812,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("context", "context_setup", "script"),
     )
     def scripts_painless_execute(
         self,
@@ -2775,6 +2824,7 @@ class Elasticsearch(BaseClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         script: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows an arbitrary script to be executed and a result to be returned
@@ -2786,12 +2836,8 @@ class Elasticsearch(BaseClient):
         :param script: The Painless script to execute.
         """
         __path = "/_scripts/painless/_execute"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if context is not None:
-            __body["context"] = context
-        if context_setup is not None:
-            __body["context_setup"] = context_setup
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2800,8 +2846,13 @@ class Elasticsearch(BaseClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if script is not None:
-            __body["script"] = script
+        if not __body:
+            if context is not None:
+                __body["context"] = context
+            if context_setup is not None:
+                __body["context_setup"] = context_setup
+            if script is not None:
+                __body["script"] = script
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2812,18 +2863,19 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("scroll_id", "scroll"),
     )
     def scroll(
         self,
         *,
-        scroll_id: str,
+        scroll_id: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         rest_total_hits_as_int: t.Optional[bool] = None,
         scroll: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to retrieve a large numbers of results from a single search request.
@@ -2836,13 +2888,11 @@ class Elasticsearch(BaseClient):
             is returned as an object.
         :param scroll: Period to retain the search context for scrolling.
         """
-        if scroll_id is None:
+        if scroll_id is None and body is None:
             raise ValueError("Empty value passed for parameter 'scroll_id'")
         __path = "/_search/scroll"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if scroll_id is not None:
-            __body["scroll_id"] = scroll_id
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2853,8 +2903,11 @@ class Elasticsearch(BaseClient):
             __query["pretty"] = pretty
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
-        if scroll is not None:
-            __body["scroll"] = scroll
+        if not __body:
+            if scroll_id is not None:
+                __body["scroll_id"] = scroll_id
+            if scroll is not None:
+                __body["scroll"] = scroll
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2865,7 +2918,42 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rank",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -2967,6 +3055,7 @@ class Elasticsearch(BaseClient):
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         typed_keys: t.Optional[bool] = None,
         version: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query.
@@ -3163,8 +3252,8 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_search"
         else:
             __path = "/_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3176,10 +3265,6 @@ class Elasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -3192,106 +3277,52 @@ class Elasticsearch(BaseClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if force_synthetic_source is not None:
             __query["force_synthetic_source"] = force_synthetic_source
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
-        if rank is not None:
-            __body["rank"] = rank
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -3300,18 +3331,77 @@ class Elasticsearch(BaseClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rank is not None:
+                __body["rank"] = rank
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3322,7 +3412,22 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggs",
+            "buffer",
+            "exact_bounds",
+            "extent",
+            "fields",
+            "grid_agg",
+            "grid_precision",
+            "grid_type",
+            "query",
+            "runtime_mappings",
+            "size",
+            "sort",
+            "track_total_hits",
+            "with_labels",
+        ),
     )
     def search_mvt(
         self,
@@ -3357,6 +3462,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         track_total_hits: t.Optional[t.Union[bool, int]] = None,
         with_labels: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> BinaryApiResponse:
         """
         Searches a vector tile for geospatial values. Returns results as a binary Mapbox
@@ -3418,8 +3524,8 @@ class Elasticsearch(BaseClient):
         if y in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'y'")
         __path = f"/{_quote(index)}/_mvt/{_quote(field)}/{_quote(zoom)}/{_quote(x)}/{_quote(y)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -3431,42 +3537,43 @@ class Elasticsearch(BaseClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggs is not None:
-            __body["aggs"] = aggs
-        if buffer is not None:
-            __body["buffer"] = buffer
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exact_bounds is not None:
-            __body["exact_bounds"] = exact_bounds
-        if extent is not None:
-            __body["extent"] = extent
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if grid_agg is not None:
-            __body["grid_agg"] = grid_agg
-        if grid_precision is not None:
-            __body["grid_precision"] = grid_precision
-        if grid_type is not None:
-            __body["grid_type"] = grid_type
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
-        if with_labels is not None:
-            __body["with_labels"] = with_labels
+        if not __body:
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if buffer is not None:
+                __body["buffer"] = buffer
+            if exact_bounds is not None:
+                __body["exact_bounds"] = exact_bounds
+            if extent is not None:
+                __body["extent"] = extent
+            if fields is not None:
+                __body["fields"] = fields
+            if grid_agg is not None:
+                __body["grid_agg"] = grid_agg
+            if grid_precision is not None:
+                __body["grid_precision"] = grid_precision
+            if grid_type is not None:
+                __body["grid_type"] = grid_type
+            if query is not None:
+                __body["query"] = query
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if with_labels is not None:
+                __body["with_labels"] = with_labels
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/vnd.mapbox-vector-tile"}
@@ -3477,7 +3584,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("explain", "id", "params", "profile", "source"),
         ignore_deprecated_options={"params"},
     )
     def search_template(
@@ -3513,6 +3620,7 @@ class Elasticsearch(BaseClient):
         ] = None,
         source: t.Optional[str] = None,
         typed_keys: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to use the Mustache language to pre-render a search definition.
@@ -3562,7 +3670,7 @@ class Elasticsearch(BaseClient):
         else:
             __path = "/_search/template"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if ccs_minimize_roundtrips is not None:
@@ -3571,26 +3679,18 @@ class Elasticsearch(BaseClient):
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if params is not None:
-            __body["params"] = params
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
@@ -3599,23 +3699,40 @@ class Elasticsearch(BaseClient):
             __query["scroll"] = scroll
         if search_type is not None:
             __query["search_type"] = search_type
-        if source is not None:
-            __body["source"] = source
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
+        if not __body:
+            if explain is not None:
+                __body["explain"] = explain
+            if id is not None:
+                __body["id"] = id
+            if params is not None:
+                __body["params"] = params
+            if profile is not None:
+                __body["profile"] = profile
+            if source is not None:
+                __body["source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "field",
+            "case_insensitive",
+            "index_filter",
+            "search_after",
+            "size",
+            "string",
+            "timeout",
+        ),
     )
     def terms_enum(
         self,
         *,
         index: str,
-        field: str,
+        field: t.Optional[str] = None,
         case_insensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -3626,6 +3743,7 @@ class Elasticsearch(BaseClient):
         size: t.Optional[int] = None,
         string: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         The terms enum API can be used to discover terms in the index that begin with
@@ -3653,33 +3771,34 @@ class Elasticsearch(BaseClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if field is None:
+        if field is None and body is None:
             raise ValueError("Empty value passed for parameter 'field'")
         __path = f"/{_quote(index)}/_terms_enum"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if field is not None:
-            __body["field"] = field
-        if case_insensitive is not None:
-            __body["case_insensitive"] = case_insensitive
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_filter is not None:
-            __body["index_filter"] = index_filter
         if pretty is not None:
             __query["pretty"] = pretty
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if string is not None:
-            __body["string"] = string
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if field is not None:
+                __body["field"] = field
+            if case_insensitive is not None:
+                __body["case_insensitive"] = case_insensitive
+            if index_filter is not None:
+                __body["index_filter"] = index_filter
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if string is not None:
+                __body["string"] = string
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -3690,7 +3809,7 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("doc", "filter", "per_field_analyzer"),
     )
     def termvectors(
         self,
@@ -3717,6 +3836,7 @@ class Elasticsearch(BaseClient):
         version_type: t.Optional[
             t.Union["t.Literal['external', 'external_gte', 'force', 'internal']", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns information and statistics about terms in the fields of a particular
@@ -3755,18 +3875,14 @@ class Elasticsearch(BaseClient):
             __path = f"/{_quote(index)}/_termvectors"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if doc is not None:
-            __body["doc"] = doc
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if field_statistics is not None:
             __query["field_statistics"] = field_statistics
         if fields is not None:
             __query["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -3775,8 +3891,6 @@ class Elasticsearch(BaseClient):
             __query["offsets"] = offsets
         if payloads is not None:
             __query["payloads"] = payloads
-        if per_field_analyzer is not None:
-            __body["per_field_analyzer"] = per_field_analyzer
         if positions is not None:
             __query["positions"] = positions
         if preference is not None:
@@ -3794,6 +3908,13 @@ class Elasticsearch(BaseClient):
         if version_type is not None:
             __query["version_type"] = version_type
         if not __body:
+            if doc is not None:
+                __body["doc"] = doc
+            if filter is not None:
+                __body["filter"] = filter
+            if per_field_analyzer is not None:
+                __body["per_field_analyzer"] = per_field_analyzer
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -3803,7 +3924,15 @@ class Elasticsearch(BaseClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "detect_noop",
+            "doc",
+            "doc_as_upsert",
+            "script",
+            "scripted_upsert",
+            "source",
+            "upsert",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -3841,6 +3970,7 @@ class Elasticsearch(BaseClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates a document with a script or partial document.
@@ -3888,14 +4018,8 @@ class Elasticsearch(BaseClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/{_quote(index)}/_update/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if detect_noop is not None:
-            __body["detect_noop"] = detect_noop
-        if doc is not None:
-            __body["doc"] = doc
-        if doc_as_upsert is not None:
-            __body["doc_as_upsert"] = doc_as_upsert
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3918,29 +4042,36 @@ class Elasticsearch(BaseClient):
             __query["retry_on_conflict"] = retry_on_conflict
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
-        if scripted_upsert is not None:
-            __body["scripted_upsert"] = scripted_upsert
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
         if timeout is not None:
             __query["timeout"] = timeout
-        if upsert is not None:
-            __body["upsert"] = upsert
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if detect_noop is not None:
+                __body["detect_noop"] = detect_noop
+            if doc is not None:
+                __body["doc"] = doc
+            if doc_as_upsert is not None:
+                __body["doc_as_upsert"] = doc_as_upsert
+            if script is not None:
+                __body["script"] = script
+            if scripted_upsert is not None:
+                __body["scripted_upsert"] = scripted_upsert
+            if source is not None:
+                __body["_source"] = source
+            if upsert is not None:
+                __body["upsert"] = upsert
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("conflicts", "max_docs", "query", "script", "slice"),
         parameter_aliases={"from": "from_"},
     )
     def update_by_query(
@@ -3997,6 +4128,7 @@ class Elasticsearch(BaseClient):
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates documents that match the specified query. If no query is specified, performs
@@ -4079,7 +4211,7 @@ class Elasticsearch(BaseClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_update_by_query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -4097,8 +4229,6 @@ class Elasticsearch(BaseClient):
             __query["analyze_wildcard"] = analyze_wildcard
         if analyzer is not None:
             __query["analyzer"] = analyzer
-        if conflicts is not None:
-            __body["conflicts"] = conflicts
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
@@ -4117,16 +4247,12 @@ class Elasticsearch(BaseClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if lenient is not None:
             __query["lenient"] = lenient
-        if max_docs is not None:
-            __body["max_docs"] = max_docs
         if pipeline is not None:
             __query["pipeline"] = pipeline
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if refresh is not None:
             __query["refresh"] = refresh
         if request_cache is not None:
@@ -4135,8 +4261,6 @@ class Elasticsearch(BaseClient):
             __query["requests_per_second"] = requests_per_second
         if routing is not None:
             __query["routing"] = routing
-        if script is not None:
-            __body["script"] = script
         if scroll is not None:
             __query["scroll"] = scroll
         if scroll_size is not None:
@@ -4145,8 +4269,6 @@ class Elasticsearch(BaseClient):
             __query["search_timeout"] = search_timeout
         if search_type is not None:
             __query["search_type"] = search_type
-        if slice is not None:
-            __body["slice"] = slice
         if slices is not None:
             __query["slices"] = slices
         if sort is not None:
@@ -4165,6 +4287,17 @@ class Elasticsearch(BaseClient):
             __query["wait_for_active_shards"] = wait_for_active_shards
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if conflicts is not None:
+                __body["conflicts"] = conflicts
+            if max_docs is not None:
+                __body["max_docs"] = max_docs
+            if query is not None:
+                __body["query"] = query
+            if script is not None:
+                __body["script"] = script
+            if slice is not None:
+                __body["slice"] = slice
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/async_search.py
+++ b/elasticsearch_serverless/_sync/client/async_search.py
@@ -156,7 +156,41 @@ class AsyncSearchClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "collapse",
+            "docvalue_fields",
+            "explain",
+            "ext",
+            "fields",
+            "from_",
+            "highlight",
+            "indices_boost",
+            "knn",
+            "min_score",
+            "pit",
+            "post_filter",
+            "profile",
+            "query",
+            "rescore",
+            "runtime_mappings",
+            "script_fields",
+            "search_after",
+            "seq_no_primary_term",
+            "size",
+            "slice",
+            "sort",
+            "source",
+            "stats",
+            "stored_fields",
+            "suggest",
+            "terminate_after",
+            "timeout",
+            "track_scores",
+            "track_total_hits",
+            "version",
+        ),
         parameter_aliases={
             "_source": "source",
             "_source_excludes": "source_excludes",
@@ -261,6 +295,7 @@ class AsyncSearchClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a search request asynchronously.
@@ -397,8 +432,8 @@ class AsyncSearchClient(NamespacedClient):
             __path = f"/{_quote(index)}/_async_search"
         else:
             __path = "/_async_search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -410,10 +445,6 @@ class AsyncSearchClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
         if allow_partial_search_results is not None:
@@ -426,106 +457,54 @@ class AsyncSearchClient(NamespacedClient):
             __query["batched_reduce_size"] = batched_reduce_size
         if ccs_minimize_roundtrips is not None:
             __query["ccs_minimize_roundtrips"] = ccs_minimize_roundtrips
-        if collapse is not None:
-            __body["collapse"] = collapse
         if default_operator is not None:
             __query["default_operator"] = default_operator
         if df is not None:
             __query["df"] = df
-        if docvalue_fields is not None:
-            __body["docvalue_fields"] = docvalue_fields
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if explain is not None:
-            __body["explain"] = explain
-        if ext is not None:
-            __body["ext"] = ext
-        if fields is not None:
-            __body["fields"] = fields
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
-        if highlight is not None:
-            __body["highlight"] = highlight
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indices_boost is not None:
-            __body["indices_boost"] = indices_boost
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
-        if knn is not None:
-            __body["knn"] = knn
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
         if min_compatible_shard_node is not None:
             __query["min_compatible_shard_node"] = min_compatible_shard_node
-        if min_score is not None:
-            __body["min_score"] = min_score
-        if pit is not None:
-            __body["pit"] = pit
-        if post_filter is not None:
-            __body["post_filter"] = post_filter
         if pre_filter_shard_size is not None:
             __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
             __query["pretty"] = pretty
-        if profile is not None:
-            __body["profile"] = profile
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if request_cache is not None:
             __query["request_cache"] = request_cache
-        if rescore is not None:
-            __body["rescore"] = rescore
         if rest_total_hits_as_int is not None:
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
         if scroll is not None:
             __query["scroll"] = scroll
-        if search_after is not None:
-            __body["search_after"] = search_after
         if search_type is not None:
             __query["search_type"] = search_type
-        if seq_no_primary_term is not None:
-            __body["seq_no_primary_term"] = seq_no_primary_term
-        if size is not None:
-            __body["size"] = size
-        if slice is not None:
-            __body["slice"] = slice
-        if sort is not None:
-            __body["sort"] = sort
-        if source is not None:
-            __body["_source"] = source
         if source_excludes is not None:
             __query["_source_excludes"] = source_excludes
         if source_includes is not None:
             __query["_source_includes"] = source_includes
-        if stats is not None:
-            __body["stats"] = stats
-        if stored_fields is not None:
-            __body["stored_fields"] = stored_fields
-        if suggest is not None:
-            __body["suggest"] = suggest
         if suggest_field is not None:
             __query["suggest_field"] = suggest_field
         if suggest_mode is not None:
@@ -534,20 +513,77 @@ class AsyncSearchClient(NamespacedClient):
             __query["suggest_size"] = suggest_size
         if suggest_text is not None:
             __query["suggest_text"] = suggest_text
-        if terminate_after is not None:
-            __body["terminate_after"] = terminate_after
-        if timeout is not None:
-            __body["timeout"] = timeout
-        if track_scores is not None:
-            __body["track_scores"] = track_scores
-        if track_total_hits is not None:
-            __body["track_total_hits"] = track_total_hits
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
-        if version is not None:
-            __body["version"] = version
         if wait_for_completion_timeout is not None:
             __query["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if collapse is not None:
+                __body["collapse"] = collapse
+            if docvalue_fields is not None:
+                __body["docvalue_fields"] = docvalue_fields
+            if explain is not None:
+                __body["explain"] = explain
+            if ext is not None:
+                __body["ext"] = ext
+            if fields is not None:
+                __body["fields"] = fields
+            if from_ is not None:
+                __body["from"] = from_
+            if highlight is not None:
+                __body["highlight"] = highlight
+            if indices_boost is not None:
+                __body["indices_boost"] = indices_boost
+            if knn is not None:
+                __body["knn"] = knn
+            if min_score is not None:
+                __body["min_score"] = min_score
+            if pit is not None:
+                __body["pit"] = pit
+            if post_filter is not None:
+                __body["post_filter"] = post_filter
+            if profile is not None:
+                __body["profile"] = profile
+            if query is not None:
+                __body["query"] = query
+            if rescore is not None:
+                __body["rescore"] = rescore
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if seq_no_primary_term is not None:
+                __body["seq_no_primary_term"] = seq_no_primary_term
+            if size is not None:
+                __body["size"] = size
+            if slice is not None:
+                __body["slice"] = slice
+            if sort is not None:
+                __body["sort"] = sort
+            if source is not None:
+                __body["_source"] = source
+            if stats is not None:
+                __body["stats"] = stats
+            if stored_fields is not None:
+                __body["stored_fields"] = stored_fields
+            if suggest is not None:
+                __body["suggest"] = suggest
+            if terminate_after is not None:
+                __body["terminate_after"] = terminate_after
+            if timeout is not None:
+                __body["timeout"] = timeout
+            if track_scores is not None:
+                __body["track_scores"] = track_scores
+            if track_total_hits is not None:
+                __body["track_total_hits"] = track_total_hits
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/cluster.py
+++ b/elasticsearch_serverless/_sync/client/cluster.py
@@ -225,14 +225,14 @@ class ClusterClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("template", "allow_auto_create", "meta", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     def put_component_template(
         self,
         *,
         name: str,
-        template: t.Mapping[str, t.Any],
+        template: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_auto_create: t.Optional[bool] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -244,6 +244,7 @@ class ClusterClient(NamespacedClient):
         meta: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a component template
@@ -281,15 +282,11 @@ class ClusterClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if template is None:
+        if template is None and body is None:
             raise ValueError("Empty value passed for parameter 'template'")
         __path = f"/_component_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if template is not None:
-            __body["template"] = template
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -300,12 +297,17 @@ class ClusterClient(NamespacedClient):
             __query["human"] = human
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if template is not None:
+                __body["template"] = template
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if meta is not None:
+                __body["_meta"] = meta
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/enrich.py
+++ b/elasticsearch_serverless/_sync/client/enrich.py
@@ -135,7 +135,7 @@ class EnrichClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("geo_match", "match", "range"),
     )
     def put_policy(
         self,
@@ -148,6 +148,7 @@ class EnrichClient(NamespacedClient):
         match: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         range: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a new enrich policy.
@@ -165,21 +166,22 @@ class EnrichClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_enrich/policy/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if geo_match is not None:
-            __body["geo_match"] = geo_match
         if human is not None:
             __query["human"] = human
-        if match is not None:
-            __body["match"] = match
         if pretty is not None:
             __query["pretty"] = pretty
-        if range is not None:
-            __body["range"] = range
+        if not __body:
+            if geo_match is not None:
+                __body["geo_match"] = geo_match
+            if match is not None:
+                __body["match"] = match
+            if range is not None:
+                __body["range"] = range
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/eql.py
+++ b/elasticsearch_serverless/_sync/client/eql.py
@@ -146,13 +146,28 @@ class EqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "query",
+            "case_sensitive",
+            "event_category_field",
+            "fetch_size",
+            "fields",
+            "filter",
+            "keep_alive",
+            "keep_on_completion",
+            "result_position",
+            "runtime_mappings",
+            "size",
+            "tiebreaker_field",
+            "timestamp_field",
+            "wait_for_completion_timeout",
+        ),
     )
     def search(
         self,
         *,
         index: t.Union[str, t.Sequence[str]],
-        query: str,
+        query: t.Optional[str] = None,
         allow_no_indices: t.Optional[bool] = None,
         case_sensitive: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -186,6 +201,7 @@ class EqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Returns results matching a query expressed in Event Query Language (EQL)
@@ -220,53 +236,54 @@ class EqlClient(NamespacedClient):
         """
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = f"/{_quote(index)}/_eql/search"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if case_sensitive is not None:
-            __body["case_sensitive"] = case_sensitive
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if event_category_field is not None:
-            __body["event_category_field"] = event_category_field
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if fields is not None:
-            __body["fields"] = fields
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
         if pretty is not None:
             __query["pretty"] = pretty
-        if result_position is not None:
-            __body["result_position"] = result_position
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if size is not None:
-            __body["size"] = size
-        if tiebreaker_field is not None:
-            __body["tiebreaker_field"] = tiebreaker_field
-        if timestamp_field is not None:
-            __body["timestamp_field"] = timestamp_field
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if case_sensitive is not None:
+                __body["case_sensitive"] = case_sensitive
+            if event_category_field is not None:
+                __body["event_category_field"] = event_category_field
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if fields is not None:
+                __body["fields"] = fields
+            if filter is not None:
+                __body["filter"] = filter
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if result_position is not None:
+                __body["result_position"] = result_position
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if size is not None:
+                __body["size"] = size
+            if tiebreaker_field is not None:
+                __body["tiebreaker_field"] = tiebreaker_field
+            if timestamp_field is not None:
+                __body["timestamp_field"] = timestamp_field
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/graph.py
+++ b/elasticsearch_serverless/_sync/client/graph.py
@@ -26,7 +26,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class GraphClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("connections", "controls", "query", "vertices"),
     )
     def explore(
         self,
@@ -42,6 +42,7 @@ class GraphClient(NamespacedClient):
         routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         vertices: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Explore extracted and summarized information about the documents and terms in
@@ -65,12 +66,8 @@ class GraphClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_graph/explore"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if connections is not None:
-            __body["connections"] = connections
-        if controls is not None:
-            __body["controls"] = controls
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -79,14 +76,19 @@ class GraphClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
         if routing is not None:
             __query["routing"] = routing
         if timeout is not None:
             __query["timeout"] = timeout
-        if vertices is not None:
-            __body["vertices"] = vertices
+        if not __body:
+            if connections is not None:
+                __body["connections"] = connections
+            if controls is not None:
+                __body["controls"] = controls
+            if query is not None:
+                __body["query"] = query
+            if vertices is not None:
+                __body["vertices"] = vertices
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/indices.py
+++ b/elasticsearch_serverless/_sync/client/indices.py
@@ -97,7 +97,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analyzer",
+            "attributes",
+            "char_filter",
+            "explain",
+            "field",
+            "filter",
+            "normalizer",
+            "text",
+            "tokenizer",
+        ),
     )
     def analyze(
         self,
@@ -116,6 +126,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         text: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         tokenizer: t.Optional[t.Union[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Performs the analysis process on a text and return the tokens breakdown of the
@@ -148,34 +159,35 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(index)}/_analyze"
         else:
             __path = "/_analyze"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analyzer is not None:
-            __body["analyzer"] = analyzer
-        if attributes is not None:
-            __body["attributes"] = attributes
-        if char_filter is not None:
-            __body["char_filter"] = char_filter
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if explain is not None:
-            __body["explain"] = explain
-        if field is not None:
-            __body["field"] = field
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if normalizer is not None:
-            __body["normalizer"] = normalizer
         if pretty is not None:
             __query["pretty"] = pretty
-        if text is not None:
-            __body["text"] = text
-        if tokenizer is not None:
-            __body["tokenizer"] = tokenizer
+        if not __body:
+            if analyzer is not None:
+                __body["analyzer"] = analyzer
+            if attributes is not None:
+                __body["attributes"] = attributes
+            if char_filter is not None:
+                __body["char_filter"] = char_filter
+            if explain is not None:
+                __body["explain"] = explain
+            if field is not None:
+                __body["field"] = field
+            if filter is not None:
+                __body["filter"] = filter
+            if normalizer is not None:
+                __body["normalizer"] = normalizer
+            if text is not None:
+                __body["text"] = text
+            if tokenizer is not None:
+                __body["tokenizer"] = tokenizer
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -186,7 +198,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "mappings", "settings"),
     )
     def create(
         self,
@@ -206,6 +218,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an index with optional settings and mappings.
@@ -229,28 +242,29 @@ class IndicesClient(NamespacedClient):
         if index in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1398,16 +1412,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     def modify_data_stream(
         self,
         *,
-        actions: t.Sequence[t.Mapping[str, t.Any]],
+        actions: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Modifies a data stream
@@ -1416,13 +1431,11 @@ class IndicesClient(NamespacedClient):
 
         :param actions: Actions to perform.
         """
-        if actions is None:
+        if actions is None and body is None:
             raise ValueError("Empty value passed for parameter 'actions'")
         __path = "/_data_stream/_modify"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1431,13 +1444,22 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "filter",
+            "index_routing",
+            "is_write_index",
+            "routing",
+            "search_routing",
+        ),
     )
     def put_alias(
         self,
@@ -1457,6 +1479,7 @@ class IndicesClient(NamespacedClient):
         routing: t.Optional[str] = None,
         search_routing: t.Optional[str] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an alias.
@@ -1495,29 +1518,30 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/{_quote(index)}/_alias/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_routing is not None:
-            __body["index_routing"] = index_routing
-        if is_write_index is not None:
-            __body["is_write_index"] = is_write_index
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if routing is not None:
-            __body["routing"] = routing
-        if search_routing is not None:
-            __body["search_routing"] = search_routing
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if filter is not None:
+                __body["filter"] = filter
+            if index_routing is not None:
+                __body["index_routing"] = index_routing
+            if is_write_index is not None:
+                __body["is_write_index"] = is_write_index
+            if routing is not None:
+                __body["routing"] = routing
+            if search_routing is not None:
+                __body["search_routing"] = search_routing
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1528,7 +1552,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("data_retention", "downsampling"),
     )
     def put_data_lifecycle(
         self,
@@ -1554,6 +1578,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the data stream lifecycle of the selected data streams.
@@ -1581,12 +1606,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_data_stream/{_quote(name)}/_lifecycle"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if data_retention is not None:
-            __body["data_retention"] = data_retention
-        if downsampling is not None:
-            __body["downsampling"] = downsampling
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
@@ -1602,6 +1623,11 @@ class IndicesClient(NamespacedClient):
         if timeout is not None:
             __query["timeout"] = timeout
         if not __body:
+            if data_retention is not None:
+                __body["data_retention"] = data_retention
+            if downsampling is not None:
+                __body["downsampling"] = downsampling
+        if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
         if __body is not None:
@@ -1611,7 +1637,15 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "composed_of",
+            "data_stream",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def put_index_template(
@@ -1630,6 +1664,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -1661,39 +1696,52 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_index_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "date_detection",
+            "dynamic",
+            "dynamic_date_formats",
+            "dynamic_templates",
+            "field_names",
+            "meta",
+            "numeric_detection",
+            "properties",
+            "routing",
+            "runtime",
+            "source",
+        ),
         parameter_aliases={
             "_field_names": "field_names",
             "_meta": "meta",
@@ -1742,6 +1790,7 @@ class IndicesClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         write_index_only: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the index mappings.
@@ -1788,23 +1837,13 @@ class IndicesClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'index'")
         __path = f"/{_quote(index)}/_mapping"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if date_detection is not None:
-            __body["date_detection"] = date_detection
-        if dynamic is not None:
-            __body["dynamic"] = dynamic
-        if dynamic_date_formats is not None:
-            __body["dynamic_date_formats"] = dynamic_date_formats
-        if dynamic_templates is not None:
-            __body["dynamic_templates"] = dynamic_templates
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
-        if field_names is not None:
-            __body["_field_names"] = field_names
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
@@ -1813,24 +1852,35 @@ class IndicesClient(NamespacedClient):
             __query["ignore_unavailable"] = ignore_unavailable
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if numeric_detection is not None:
-            __body["numeric_detection"] = numeric_detection
         if pretty is not None:
             __query["pretty"] = pretty
-        if properties is not None:
-            __body["properties"] = properties
-        if routing is not None:
-            __body["_routing"] = routing
-        if runtime is not None:
-            __body["runtime"] = runtime
-        if source is not None:
-            __body["_source"] = source
         if timeout is not None:
             __query["timeout"] = timeout
         if write_index_only is not None:
             __query["write_index_only"] = write_index_only
+        if not __body:
+            if date_detection is not None:
+                __body["date_detection"] = date_detection
+            if dynamic is not None:
+                __body["dynamic"] = dynamic
+            if dynamic_date_formats is not None:
+                __body["dynamic_date_formats"] = dynamic_date_formats
+            if dynamic_templates is not None:
+                __body["dynamic_templates"] = dynamic_templates
+            if field_names is not None:
+                __body["_field_names"] = field_names
+            if meta is not None:
+                __body["_meta"] = meta
+            if numeric_detection is not None:
+                __body["numeric_detection"] = numeric_detection
+            if properties is not None:
+                __body["properties"] = properties
+            if routing is not None:
+                __body["_routing"] = routing
+            if runtime is not None:
+                __body["runtime"] = runtime
+            if source is not None:
+                __body["_source"] = source
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -1842,7 +1892,8 @@ class IndicesClient(NamespacedClient):
     def put_settings(
         self,
         *,
-        settings: t.Mapping[str, t.Any],
+        settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         index: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         allow_no_indices: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
@@ -1892,8 +1943,12 @@ class IndicesClient(NamespacedClient):
         :param timeout: Period to wait for a response. If no response is received before
             the timeout expires, the request fails and returns an error.
         """
-        if settings is None:
-            raise ValueError("Empty value passed for parameter 'settings'")
+        if settings is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'settings' and 'body', one of them should be set."
+            )
+        elif settings is not None and body is not None:
+            raise ValueError("Cannot set both 'settings' and 'body'")
         if index not in SKIP_IN_PATH:
             __path = f"/{_quote(index)}/_settings"
         else:
@@ -1921,14 +1976,21 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
-        __body = settings
+        __body = settings if settings is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aliases",
+            "index_patterns",
+            "mappings",
+            "order",
+            "settings",
+            "version",
+        ),
     )
     def put_template(
         self,
@@ -1950,6 +2012,7 @@ class IndicesClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates an index template.
@@ -1980,10 +2043,8 @@ class IndicesClient(NamespacedClient):
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_template/{_quote(name)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
         if error_trace is not None:
@@ -1994,22 +2055,25 @@ class IndicesClient(NamespacedClient):
             __query["flat_settings"] = flat_settings
         if human is not None:
             __query["human"] = human
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if order is not None:
-            __body["order"] = order
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if order is not None:
+                __body["order"] = order
+            if settings is not None:
+                __body["settings"] = settings
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2128,7 +2192,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("aliases", "conditions", "mappings", "settings"),
     )
     def rollover(
         self,
@@ -2151,6 +2215,7 @@ class IndicesClient(NamespacedClient):
         wait_for_active_shards: t.Optional[
             t.Union[int, t.Union["t.Literal['all', 'index-setting']", str]]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates an alias to point to a new index when the existing index is considered
@@ -2192,12 +2257,8 @@ class IndicesClient(NamespacedClient):
             __path = f"/{_quote(alias)}/_rollover"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aliases is not None:
-            __body["aliases"] = aliases
-        if conditions is not None:
-            __body["conditions"] = conditions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if dry_run is not None:
             __query["dry_run"] = dry_run
         if error_trace is not None:
@@ -2206,18 +2267,23 @@ class IndicesClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if mappings is not None:
-            __body["mappings"] = mappings
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
-        if settings is not None:
-            __body["settings"] = settings
         if timeout is not None:
             __query["timeout"] = timeout
         if wait_for_active_shards is not None:
             __query["wait_for_active_shards"] = wait_for_active_shards
+        if not __body:
+            if aliases is not None:
+                __body["aliases"] = aliases
+            if conditions is not None:
+                __body["conditions"] = conditions
+            if mappings is not None:
+                __body["mappings"] = mappings
+            if settings is not None:
+                __body["settings"] = settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2275,7 +2341,17 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_auto_create",
+            "composed_of",
+            "data_stream",
+            "ignore_missing_component_templates",
+            "index_patterns",
+            "meta",
+            "priority",
+            "template",
+            "version",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def simulate_template(
@@ -2300,6 +2376,7 @@ class IndicesClient(NamespacedClient):
         priority: t.Optional[int] = None,
         template: t.Optional[t.Mapping[str, t.Any]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Simulate resolving the given template name or body
@@ -2351,42 +2428,43 @@ class IndicesClient(NamespacedClient):
             __path = f"/_index_template/_simulate/{_quote(name)}"
         else:
             __path = "/_index_template/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_auto_create is not None:
-            __body["allow_auto_create"] = allow_auto_create
-        if composed_of is not None:
-            __body["composed_of"] = composed_of
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if create is not None:
             __query["create"] = create
-        if data_stream is not None:
-            __body["data_stream"] = data_stream
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if ignore_missing_component_templates is not None:
-            __body["ignore_missing_component_templates"] = (
-                ignore_missing_component_templates
-            )
         if include_defaults is not None:
             __query["include_defaults"] = include_defaults
-        if index_patterns is not None:
-            __body["index_patterns"] = index_patterns
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if priority is not None:
-            __body["priority"] = priority
-        if template is not None:
-            __body["template"] = template
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if allow_auto_create is not None:
+                __body["allow_auto_create"] = allow_auto_create
+            if composed_of is not None:
+                __body["composed_of"] = composed_of
+            if data_stream is not None:
+                __body["data_stream"] = data_stream
+            if ignore_missing_component_templates is not None:
+                __body["ignore_missing_component_templates"] = (
+                    ignore_missing_component_templates
+                )
+            if index_patterns is not None:
+                __body["index_patterns"] = index_patterns
+            if meta is not None:
+                __body["_meta"] = meta
+            if priority is not None:
+                __body["priority"] = priority
+            if template is not None:
+                __body["template"] = template
+            if version is not None:
+                __body["version"] = version
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2397,7 +2475,7 @@ class IndicesClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("actions",),
     )
     def update_aliases(
         self,
@@ -2411,6 +2489,7 @@ class IndicesClient(NamespacedClient):
         ] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates index aliases.
@@ -2425,10 +2504,8 @@ class IndicesClient(NamespacedClient):
             the timeout expires, the request fails and returns an error.
         """
         __path = "/_aliases"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if actions is not None:
-            __body["actions"] = actions
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2441,13 +2518,16 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if actions is not None:
+                __body["actions"] = actions
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query",),
     )
     def validate_query(
         self,
@@ -2477,6 +2557,7 @@ class IndicesClient(NamespacedClient):
         q: t.Optional[str] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
         rewrite: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows a user to validate a potentially expensive query without executing it.
@@ -2519,7 +2600,7 @@ class IndicesClient(NamespacedClient):
         else:
             __path = "/_validate/query"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if all_shards is not None:
             __query["all_shards"] = all_shards
         if allow_no_indices is not None:
@@ -2550,10 +2631,11 @@ class IndicesClient(NamespacedClient):
             __query["pretty"] = pretty
         if q is not None:
             __query["q"] = q
-        if query is not None:
-            __body["query"] = query
         if rewrite is not None:
             __query["rewrite"] = rewrite
+        if not __body:
+            if query is not None:
+                __body["query"] = query
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/inference.py
+++ b/elasticsearch_serverless/_sync/client/inference.py
@@ -118,13 +118,13 @@ class InferenceClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("input", "query", "task_settings"),
     )
     def inference(
         self,
         *,
         inference_id: str,
-        input: t.Union[str, t.Sequence[str]],
+        input: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         task_type: t.Optional[
             t.Union[
                 "t.Literal['completion', 'rerank', 'sparse_embedding', 'text_embedding']",
@@ -137,6 +137,7 @@ class InferenceClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         query: t.Optional[str] = None,
         task_settings: t.Optional[t.Any] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Perform inference on a model
@@ -151,7 +152,7 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
-        if input is None:
+        if input is None and body is None:
             raise ValueError("Empty value passed for parameter 'input'")
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
             __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
@@ -159,10 +160,8 @@ class InferenceClient(NamespacedClient):
             __path = f"/_inference/{_quote(inference_id)}"
         else:
             raise ValueError("Couldn't find a path for the given parameters")
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if input is not None:
-            __body["input"] = input
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -171,10 +170,13 @@ class InferenceClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if task_settings is not None:
-            __body["task_settings"] = task_settings
+        if not __body:
+            if input is not None:
+                __body["input"] = input
+            if query is not None:
+                __body["query"] = query
+            if task_settings is not None:
+                __body["task_settings"] = task_settings
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -191,7 +193,8 @@ class InferenceClient(NamespacedClient):
         self,
         *,
         inference_id: str,
-        model_config: t.Mapping[str, t.Any],
+        model_config: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         task_type: t.Optional[
             t.Union[
                 "t.Literal['completion', 'rerank', 'sparse_embedding', 'text_embedding']",
@@ -214,8 +217,12 @@ class InferenceClient(NamespacedClient):
         """
         if inference_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'inference_id'")
-        if model_config is None:
-            raise ValueError("Empty value passed for parameter 'model_config'")
+        if model_config is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'model_config' and 'body', one of them should be set."
+            )
+        elif model_config is not None and body is not None:
+            raise ValueError("Cannot set both 'model_config' and 'body'")
         if task_type not in SKIP_IN_PATH and inference_id not in SKIP_IN_PATH:
             __path = f"/_inference/{_quote(task_type)}/{_quote(inference_id)}"
         elif inference_id not in SKIP_IN_PATH:
@@ -231,7 +238,7 @@ class InferenceClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = model_config
+        __body = model_config if model_config is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/ingest.py
+++ b/elasticsearch_serverless/_sync/client/ingest.py
@@ -151,7 +151,7 @@ class IngestClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "meta", "on_failure", "processors", "version"),
         parameter_aliases={"_meta": "meta"},
     )
     def put_pipeline(
@@ -172,6 +172,7 @@ class IngestClient(NamespacedClient):
         processors: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
         version: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a pipeline.
@@ -204,10 +205,8 @@ class IngestClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ingest/pipeline/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -218,25 +217,28 @@ class IngestClient(NamespacedClient):
             __query["if_version"] = if_version
         if master_timeout is not None:
             __query["master_timeout"] = master_timeout
-        if meta is not None:
-            __body["_meta"] = meta
-        if on_failure is not None:
-            __body["on_failure"] = on_failure
         if pretty is not None:
             __query["pretty"] = pretty
-        if processors is not None:
-            __body["processors"] = processors
         if timeout is not None:
             __query["timeout"] = timeout
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if meta is not None:
+                __body["_meta"] = meta
+            if on_failure is not None:
+                __body["on_failure"] = on_failure
+            if processors is not None:
+                __body["processors"] = processors
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "pipeline"),
     )
     def simulate(
         self,
@@ -249,6 +251,7 @@ class IngestClient(NamespacedClient):
         pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         verbose: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Allows to simulate a pipeline with example documents.
@@ -268,22 +271,23 @@ class IngestClient(NamespacedClient):
             __path = f"/_ingest/pipeline/{_quote(id)}/_simulate"
         else:
             __path = "/_ingest/pipeline/_simulate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if pipeline is not None:
-            __body["pipeline"] = pipeline
         if pretty is not None:
             __query["pretty"] = pretty
         if verbose is not None:
             __query["verbose"] = verbose
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if pipeline is not None:
+                __body["pipeline"] = pipeline
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/logstash.py
+++ b/elasticsearch_serverless/_sync/client/logstash.py
@@ -101,7 +101,8 @@ class LogstashClient(NamespacedClient):
         self,
         *,
         id: str,
-        pipeline: t.Mapping[str, t.Any],
+        pipeline: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
@@ -117,8 +118,12 @@ class LogstashClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if pipeline is None:
-            raise ValueError("Empty value passed for parameter 'pipeline'")
+        if pipeline is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'pipeline' and 'body', one of them should be set."
+            )
+        elif pipeline is not None and body is not None:
+            raise ValueError("Cannot set both 'pipeline' and 'body'")
         __path = f"/_logstash/pipeline/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
         if error_trace is not None:
@@ -129,7 +134,7 @@ class LogstashClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = pipeline
+        __body = pipeline if pipeline is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/ml.py
+++ b/elasticsearch_serverless/_sync/client/ml.py
@@ -26,7 +26,7 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class MlClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     def close_job(
         self,
@@ -39,6 +39,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Closes one or more anomaly detection jobs. A job can be opened and closed multiple
@@ -59,22 +60,23 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -444,7 +446,11 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "max_bucket_cardinality",
+            "overall_cardinality",
+        ),
     )
     def estimate_model_memory(
         self,
@@ -456,6 +462,7 @@ class MlClient(NamespacedClient):
         max_bucket_cardinality: t.Optional[t.Mapping[str, int]] = None,
         overall_cardinality: t.Optional[t.Mapping[str, int]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Estimates the model memory
@@ -478,40 +485,42 @@ class MlClient(NamespacedClient):
             or `partition_field_name`.
         """
         __path = "/_ml/anomaly_detectors/_estimate_model_memory"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_bucket_cardinality is not None:
-            __body["max_bucket_cardinality"] = max_bucket_cardinality
-        if overall_cardinality is not None:
-            __body["overall_cardinality"] = overall_cardinality
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if max_bucket_cardinality is not None:
+                __body["max_bucket_cardinality"] = max_bucket_cardinality
+            if overall_cardinality is not None:
+                __body["overall_cardinality"] = overall_cardinality
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("evaluation", "index", "query"),
     )
     def evaluate_data_frame(
         self,
         *,
-        evaluation: t.Mapping[str, t.Any],
-        index: str,
+        evaluation: t.Optional[t.Mapping[str, t.Any]] = None,
+        index: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         query: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluates the data frame analytics for an annotated index.
@@ -523,17 +532,13 @@ class MlClient(NamespacedClient):
         :param query: A query clause that retrieves a subset of data from the source
             index.
         """
-        if evaluation is None:
+        if evaluation is None and body is None:
             raise ValueError("Empty value passed for parameter 'evaluation'")
-        if index is None:
+        if index is None and body is None:
             raise ValueError("Empty value passed for parameter 'index'")
         __path = "/_ml/data_frame/_evaluate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if evaluation is not None:
-            __body["evaluation"] = evaluation
-        if index is not None:
-            __body["index"] = index
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -542,15 +547,20 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
+        if not __body:
+            if evaluation is not None:
+                __body["evaluation"] = evaluation
+            if index is not None:
+                __body["index"] = index
+            if query is not None:
+                __body["query"] = query
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("advance_time", "calc_interim", "end", "skip_time", "start"),
     )
     def flush_job(
         self,
@@ -565,6 +575,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         skip_time: t.Optional[t.Union[str, t.Any]] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Forces any buffered data to be processed by the job.
@@ -581,14 +592,8 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_flush"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if advance_time is not None:
-            __body["advance_time"] = advance_time
-        if calc_interim is not None:
-            __body["calc_interim"] = calc_interim
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -597,10 +602,17 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if skip_time is not None:
-            __body["skip_time"] = skip_time
-        if start is not None:
-            __body["start"] = start
+        if not __body:
+            if advance_time is not None:
+                __body["advance_time"] = advance_time
+            if calc_interim is not None:
+                __body["calc_interim"] = calc_interim
+            if end is not None:
+                __body["end"] = end
+            if skip_time is not None:
+                __body["skip_time"] = skip_time
+            if start is not None:
+                __body["start"] = start
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -671,7 +683,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("page",),
         parameter_aliases={"from": "from_"},
     )
     def get_calendars(
@@ -685,6 +697,7 @@ class MlClient(NamespacedClient):
         page: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves configuration information for calendars.
@@ -706,7 +719,7 @@ class MlClient(NamespacedClient):
         else:
             __path = "/_ml/calendars"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -715,12 +728,13 @@ class MlClient(NamespacedClient):
             __query["from"] = from_
         if human is not None:
             __query["human"] = human
-        if page is not None:
-            __body["page"] = page
         if pretty is not None:
             __query["pretty"] = pretty
         if size is not None:
             __query["size"] = size
+        if not __body:
+            if page is not None:
+                __body["page"] = page
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1103,7 +1117,15 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_no_match",
+            "bucket_span",
+            "end",
+            "exclude_interim",
+            "overall_score",
+            "start",
+            "top_n",
+        ),
     )
     def get_overall_buckets(
         self,
@@ -1120,6 +1142,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         top_n: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves overall bucket results that summarize the bucket results of multiple
@@ -1145,30 +1168,31 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/results/overall_buckets"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
-        if bucket_span is not None:
-            __body["bucket_span"] = bucket_span
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if exclude_interim is not None:
-            __body["exclude_interim"] = exclude_interim
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if overall_score is not None:
-            __body["overall_score"] = overall_score
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if top_n is not None:
-            __body["top_n"] = top_n
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if bucket_span is not None:
+                __body["bucket_span"] = bucket_span
+            if end is not None:
+                __body["end"] = end
+            if exclude_interim is not None:
+                __body["exclude_interim"] = exclude_interim
+            if overall_score is not None:
+                __body["overall_score"] = overall_score
+            if start is not None:
+                __body["start"] = start
+            if top_n is not None:
+                __body["top_n"] = top_n
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1314,19 +1338,20 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("docs", "inference_config"),
     )
     def infer_trained_model(
         self,
         *,
         model_id: str,
-        docs: t.Sequence[t.Mapping[str, t.Any]],
+        docs: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         inference_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Evaluate a trained model.
@@ -1344,32 +1369,33 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if docs is None:
+        if docs is None and body is None:
             raise ValueError("Empty value passed for parameter 'docs'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/_infer"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if docs is not None:
-            __body["docs"] = docs
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
         if pretty is not None:
             __query["pretty"] = pretty
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if docs is not None:
+                __body["docs"] = docs
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("timeout",),
     )
     def open_job(
         self,
@@ -1380,6 +1406,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Opens one or more anomaly detection jobs.
@@ -1393,7 +1420,7 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_open"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1402,8 +1429,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1414,17 +1442,18 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("events",),
     )
     def post_calendar_events(
         self,
         *,
         calendar_id: str,
-        events: t.Sequence[t.Mapping[str, t.Any]],
+        events: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Posts scheduled events in a calendar.
@@ -1438,13 +1467,11 @@ class MlClient(NamespacedClient):
         """
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
-        if events is None:
+        if events is None and body is None:
             raise ValueError("Empty value passed for parameter 'events'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}/events"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if events is not None:
-            __body["events"] = events
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1453,13 +1480,16 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if events is not None:
+                __body["events"] = events
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("config",),
     )
     def preview_data_frame_analytics(
         self,
@@ -1470,6 +1500,7 @@ class MlClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews that will be analyzed given a data frame analytics config.
@@ -1485,10 +1516,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/data_frame/analytics/{_quote(id)}/_preview"
         else:
             __path = "/_ml/data_frame/analytics/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if config is not None:
-            __body["config"] = config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -1497,6 +1526,9 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if config is not None:
+                __body["config"] = config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1507,7 +1539,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("datafeed_config", "job_config"),
     )
     def preview_datafeed(
         self,
@@ -1521,6 +1553,7 @@ class MlClient(NamespacedClient):
         job_config: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a datafeed.
@@ -1546,10 +1579,8 @@ class MlClient(NamespacedClient):
             __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_preview"
         else:
             __path = "/_ml/datafeeds/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if end is not None:
             __query["end"] = end
         if error_trace is not None:
@@ -1558,12 +1589,15 @@ class MlClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_config is not None:
-            __body["job_config"] = job_config
         if pretty is not None:
             __query["pretty"] = pretty
         if start is not None:
             __query["start"] = start
+        if not __body:
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if job_config is not None:
+                __body["job_config"] = job_config
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1574,7 +1608,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "job_ids"),
     )
     def put_calendar(
         self,
@@ -1586,6 +1620,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         job_ids: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a calendar.
@@ -1599,20 +1634,21 @@ class MlClient(NamespacedClient):
         if calendar_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'calendar_id'")
         __path = f"/_ml/calendars/{_quote(calendar_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if job_ids is not None:
-            __body["job_ids"] = job_ids
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if job_ids is not None:
+                __body["job_ids"] = job_ids
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -1662,16 +1698,27 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis",
+            "dest",
+            "source",
+            "allow_lazy_start",
+            "analyzed_fields",
+            "description",
+            "headers",
+            "max_num_threads",
+            "model_memory_limit",
+            "version",
+        ),
         ignore_deprecated_options={"headers"},
     )
     def put_data_frame_analytics(
         self,
         *,
         id: str,
-        analysis: t.Mapping[str, t.Any],
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        analysis: t.Optional[t.Mapping[str, t.Any]] = None,
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_start: t.Optional[bool] = None,
         analyzed_fields: t.Optional[t.Mapping[str, t.Any]] = None,
         description: t.Optional[str] = None,
@@ -1683,6 +1730,7 @@ class MlClient(NamespacedClient):
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         version: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a data frame analytics job.
@@ -1746,50 +1794,67 @@ class MlClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if analysis is None:
+        if analysis is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis is not None:
-            __body["analysis"] = analysis
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if analyzed_fields is not None:
-            __body["analyzed_fields"] = analyzed_fields
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
-        if version is not None:
-            __body["version"] = version
+        if not __body:
+            if analysis is not None:
+                __body["analysis"] = analysis
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if analyzed_fields is not None:
+                __body["analyzed_fields"] = analyzed_fields
+            if description is not None:
+                __body["description"] = description
+            if headers is not None:
+                __body["headers"] = headers
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
+            if version is not None:
+                __body["version"] = version
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "headers",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
         ignore_deprecated_options={"headers"},
     )
     def put_datafeed(
@@ -1826,6 +1891,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a datafeed.
@@ -1904,61 +1970,62 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
-        if headers is not None:
-            __body["headers"] = headers
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if headers is not None:
+                __body["headers"] = headers
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("description", "items"),
     )
     def put_filter(
         self,
@@ -1970,6 +2037,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         items: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a filter.
@@ -1984,34 +2052,51 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if items is not None:
-            __body["items"] = items
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if items is not None:
+                __body["items"] = items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "analysis_config",
+            "data_description",
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "datafeed_config",
+            "description",
+            "groups",
+            "model_plot_config",
+            "model_snapshot_retention_days",
+            "renormalization_window_days",
+            "results_index_name",
+            "results_retention_days",
+        ),
     )
     def put_job(
         self,
         *,
         job_id: str,
-        analysis_config: t.Mapping[str, t.Any],
-        data_description: t.Mapping[str, t.Any],
+        analysis_config: t.Optional[t.Mapping[str, t.Any]] = None,
+        data_description: t.Optional[t.Mapping[str, t.Any]] = None,
         allow_lazy_open: t.Optional[bool] = None,
         analysis_limits: t.Optional[t.Mapping[str, t.Any]] = None,
         background_persist_interval: t.Optional[
@@ -2031,6 +2116,7 @@ class MlClient(NamespacedClient):
         renormalization_window_days: t.Optional[int] = None,
         results_index_name: t.Optional[str] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates an anomaly detection job.
@@ -2112,60 +2198,73 @@ class MlClient(NamespacedClient):
         """
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
-        if analysis_config is None:
+        if analysis_config is None and body is None:
             raise ValueError("Empty value passed for parameter 'analysis_config'")
-        if data_description is None:
+        if data_description is None and body is None:
             raise ValueError("Empty value passed for parameter 'data_description'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if analysis_config is not None:
-            __body["analysis_config"] = analysis_config
-        if data_description is not None:
-            __body["data_description"] = data_description
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body["daily_model_snapshot_retention_after_days"] = (
-                daily_model_snapshot_retention_after_days
-            )
-        if datafeed_config is not None:
-            __body["datafeed_config"] = datafeed_config
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_index_name is not None:
-            __body["results_index_name"] = results_index_name
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if analysis_config is not None:
+                __body["analysis_config"] = analysis_config
+            if data_description is not None:
+                __body["data_description"] = data_description
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body["daily_model_snapshot_retention_after_days"] = (
+                    daily_model_snapshot_retention_after_days
+                )
+            if datafeed_config is not None:
+                __body["datafeed_config"] = datafeed_config
+            if description is not None:
+                __body["description"] = description
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_index_name is not None:
+                __body["results_index_name"] = results_index_name
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "compressed_definition",
+            "definition",
+            "description",
+            "inference_config",
+            "input",
+            "metadata",
+            "model_size_bytes",
+            "model_type",
+            "platform_architecture",
+            "prefix_strings",
+            "tags",
+        ),
     )
     def put_trained_model(
         self,
@@ -2190,6 +2289,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         tags: t.Optional[t.Sequence[str]] = None,
         wait_for_completion: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an inference trained model.
@@ -2232,42 +2332,43 @@ class MlClient(NamespacedClient):
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
         __path = f"/_ml/trained_models/{_quote(model_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if compressed_definition is not None:
-            __body["compressed_definition"] = compressed_definition
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_definition_decompression is not None:
             __query["defer_definition_decompression"] = defer_definition_decompression
-        if definition is not None:
-            __body["definition"] = definition
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if inference_config is not None:
-            __body["inference_config"] = inference_config
-        if input is not None:
-            __body["input"] = input
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if model_size_bytes is not None:
-            __body["model_size_bytes"] = model_size_bytes
-        if model_type is not None:
-            __body["model_type"] = model_type
-        if platform_architecture is not None:
-            __body["platform_architecture"] = platform_architecture
-        if prefix_strings is not None:
-            __body["prefix_strings"] = prefix_strings
         if pretty is not None:
             __query["pretty"] = pretty
-        if tags is not None:
-            __body["tags"] = tags
         if wait_for_completion is not None:
             __query["wait_for_completion"] = wait_for_completion
+        if not __body:
+            if compressed_definition is not None:
+                __body["compressed_definition"] = compressed_definition
+            if definition is not None:
+                __body["definition"] = definition
+            if description is not None:
+                __body["description"] = description
+            if inference_config is not None:
+                __body["inference_config"] = inference_config
+            if input is not None:
+                __body["input"] = input
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if model_size_bytes is not None:
+                __body["model_size_bytes"] = model_size_bytes
+            if model_type is not None:
+                __body["model_type"] = model_type
+            if platform_architecture is not None:
+                __body["platform_architecture"] = platform_architecture
+            if prefix_strings is not None:
+                __body["prefix_strings"] = prefix_strings
+            if tags is not None:
+                __body["tags"] = tags
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2319,20 +2420,21 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("definition", "total_definition_length", "total_parts"),
     )
     def put_trained_model_definition_part(
         self,
         *,
         model_id: str,
         part: int,
-        definition: str,
-        total_definition_length: int,
-        total_parts: int,
+        definition: t.Optional[str] = None,
+        total_definition_length: t.Optional[int] = None,
+        total_parts: t.Optional[int] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates part of a trained model definition
@@ -2354,23 +2456,17 @@ class MlClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'model_id'")
         if part in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'part'")
-        if definition is None:
+        if definition is None and body is None:
             raise ValueError("Empty value passed for parameter 'definition'")
-        if total_definition_length is None:
+        if total_definition_length is None and body is None:
             raise ValueError(
                 "Empty value passed for parameter 'total_definition_length'"
             )
-        if total_parts is None:
+        if total_parts is None and body is None:
             raise ValueError("Empty value passed for parameter 'total_parts'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/definition/{_quote(part)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if definition is not None:
-            __body["definition"] = definition
-        if total_definition_length is not None:
-            __body["total_definition_length"] = total_definition_length
-        if total_parts is not None:
-            __body["total_parts"] = total_parts
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2379,25 +2475,33 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if definition is not None:
+                __body["definition"] = definition
+            if total_definition_length is not None:
+                __body["total_definition_length"] = total_definition_length
+            if total_parts is not None:
+                __body["total_parts"] = total_parts
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("vocabulary", "merges", "scores"),
     )
     def put_trained_model_vocabulary(
         self,
         *,
         model_id: str,
-        vocabulary: t.Sequence[str],
+        vocabulary: t.Optional[t.Sequence[str]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         merges: t.Optional[t.Sequence[str]] = None,
         pretty: t.Optional[bool] = None,
         scores: t.Optional[t.Sequence[float]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates a trained model vocabulary
@@ -2411,25 +2515,26 @@ class MlClient(NamespacedClient):
         """
         if model_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'model_id'")
-        if vocabulary is None:
+        if vocabulary is None and body is None:
             raise ValueError("Empty value passed for parameter 'vocabulary'")
         __path = f"/_ml/trained_models/{_quote(model_id)}/vocabulary"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if vocabulary is not None:
-            __body["vocabulary"] = vocabulary
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if merges is not None:
-            __body["merges"] = merges
         if pretty is not None:
             __query["pretty"] = pretty
-        if scores is not None:
-            __body["scores"] = scores
+        if not __body:
+            if vocabulary is not None:
+                __body["vocabulary"] = vocabulary
+            if merges is not None:
+                __body["merges"] = merges
+            if scores is not None:
+                __body["scores"] = scores
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -2522,7 +2627,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("end", "start", "timeout"),
     )
     def start_datafeed(
         self,
@@ -2535,6 +2640,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         start: t.Optional[t.Union[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Starts one or more datafeeds.
@@ -2552,10 +2658,8 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_start"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if end is not None:
-            __body["end"] = end
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -2564,10 +2668,13 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if start is not None:
-            __body["start"] = start
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if end is not None:
+                __body["end"] = end
+            if start is not None:
+                __body["start"] = start
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2718,7 +2825,7 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("allow_no_match", "force", "timeout"),
     )
     def stop_datafeed(
         self,
@@ -2731,6 +2838,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Stops one or more datafeeds.
@@ -2749,22 +2857,23 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_stop"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_no_match is not None:
-            __body["allow_no_match"] = allow_no_match
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if force is not None:
-            __body["force"] = force
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if timeout is not None:
-            __body["timeout"] = timeout
+        if not __body:
+            if allow_no_match is not None:
+                __body["allow_no_match"] = allow_no_match
+            if force is not None:
+                __body["force"] = force
+            if timeout is not None:
+                __body["timeout"] = timeout
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -2824,7 +2933,12 @@ class MlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_start",
+            "description",
+            "max_num_threads",
+            "model_memory_limit",
+        ),
     )
     def update_data_frame_analytics(
         self,
@@ -2838,6 +2952,7 @@ class MlClient(NamespacedClient):
         max_num_threads: t.Optional[int] = None,
         model_memory_limit: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a data frame analytics job.
@@ -2863,31 +2978,47 @@ class MlClient(NamespacedClient):
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_ml/data_frame/analytics/{_quote(id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_start is not None:
-            __body["allow_lazy_start"] = allow_lazy_start
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if max_num_threads is not None:
-            __body["max_num_threads"] = max_num_threads
-        if model_memory_limit is not None:
-            __body["model_memory_limit"] = model_memory_limit
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if allow_lazy_start is not None:
+                __body["allow_lazy_start"] = allow_lazy_start
+            if description is not None:
+                __body["description"] = description
+            if max_num_threads is not None:
+                __body["max_num_threads"] = max_num_threads
+            if model_memory_limit is not None:
+                __body["model_memory_limit"] = model_memory_limit
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "chunking_config",
+            "delayed_data_check_config",
+            "frequency",
+            "indexes",
+            "indices",
+            "indices_options",
+            "job_id",
+            "max_empty_searches",
+            "query",
+            "query_delay",
+            "runtime_mappings",
+            "script_fields",
+            "scroll_size",
+        ),
     )
     def update_datafeed(
         self,
@@ -2922,6 +3053,7 @@ class MlClient(NamespacedClient):
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         scroll_size: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a datafeed.
@@ -3011,59 +3143,60 @@ class MlClient(NamespacedClient):
         if datafeed_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'datafeed_id'")
         __path = f"/_ml/datafeeds/{_quote(datafeed_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if allow_no_indices is not None:
             __query["allow_no_indices"] = allow_no_indices
-        if chunking_config is not None:
-            __body["chunking_config"] = chunking_config
-        if delayed_data_check_config is not None:
-            __body["delayed_data_check_config"] = delayed_data_check_config
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:
             __query["expand_wildcards"] = expand_wildcards
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
         if ignore_throttled is not None:
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if indexes is not None:
-            __body["indexes"] = indexes
-        if indices is not None:
-            __body["indices"] = indices
-        if indices_options is not None:
-            __body["indices_options"] = indices_options
-        if job_id is not None:
-            __body["job_id"] = job_id
-        if max_empty_searches is not None:
-            __body["max_empty_searches"] = max_empty_searches
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if query_delay is not None:
-            __body["query_delay"] = query_delay
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if script_fields is not None:
-            __body["script_fields"] = script_fields
-        if scroll_size is not None:
-            __body["scroll_size"] = scroll_size
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if chunking_config is not None:
+                __body["chunking_config"] = chunking_config
+            if delayed_data_check_config is not None:
+                __body["delayed_data_check_config"] = delayed_data_check_config
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if indexes is not None:
+                __body["indexes"] = indexes
+            if indices is not None:
+                __body["indices"] = indices
+            if indices_options is not None:
+                __body["indices_options"] = indices_options
+            if job_id is not None:
+                __body["job_id"] = job_id
+            if max_empty_searches is not None:
+                __body["max_empty_searches"] = max_empty_searches
+            if query is not None:
+                __body["query"] = query
+            if query_delay is not None:
+                __body["query_delay"] = query_delay
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if script_fields is not None:
+                __body["script_fields"] = script_fields
+            if scroll_size is not None:
+                __body["scroll_size"] = scroll_size
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("add_items", "description", "remove_items"),
     )
     def update_filter(
         self,
@@ -3076,6 +3209,7 @@ class MlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         remove_items: t.Optional[t.Sequence[str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates the description of a filter, adds items, or removes items.
@@ -3090,12 +3224,8 @@ class MlClient(NamespacedClient):
         if filter_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'filter_id'")
         __path = f"/_ml/filters/{_quote(filter_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if add_items is not None:
-            __body["add_items"] = add_items
-        if description is not None:
-            __body["description"] = description
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -3104,15 +3234,36 @@ class MlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if remove_items is not None:
-            __body["remove_items"] = remove_items
+        if not __body:
+            if add_items is not None:
+                __body["add_items"] = add_items
+            if description is not None:
+                __body["description"] = description
+            if remove_items is not None:
+                __body["remove_items"] = remove_items
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "allow_lazy_open",
+            "analysis_limits",
+            "background_persist_interval",
+            "categorization_filters",
+            "custom_settings",
+            "daily_model_snapshot_retention_after_days",
+            "description",
+            "detectors",
+            "groups",
+            "model_plot_config",
+            "model_prune_window",
+            "model_snapshot_retention_days",
+            "per_partition_categorization",
+            "renormalization_window_days",
+            "results_retention_days",
+        ),
     )
     def update_job(
         self,
@@ -3141,6 +3292,7 @@ class MlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         renormalization_window_days: t.Optional[int] = None,
         results_retention_days: t.Optional[int] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of an anomaly detection job.
@@ -3199,48 +3351,49 @@ class MlClient(NamespacedClient):
         if job_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'job_id'")
         __path = f"/_ml/anomaly_detectors/{_quote(job_id)}/_update"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if allow_lazy_open is not None:
-            __body["allow_lazy_open"] = allow_lazy_open
-        if analysis_limits is not None:
-            __body["analysis_limits"] = analysis_limits
-        if background_persist_interval is not None:
-            __body["background_persist_interval"] = background_persist_interval
-        if categorization_filters is not None:
-            __body["categorization_filters"] = categorization_filters
-        if custom_settings is not None:
-            __body["custom_settings"] = custom_settings
-        if daily_model_snapshot_retention_after_days is not None:
-            __body["daily_model_snapshot_retention_after_days"] = (
-                daily_model_snapshot_retention_after_days
-            )
-        if description is not None:
-            __body["description"] = description
-        if detectors is not None:
-            __body["detectors"] = detectors
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if groups is not None:
-            __body["groups"] = groups
         if human is not None:
             __query["human"] = human
-        if model_plot_config is not None:
-            __body["model_plot_config"] = model_plot_config
-        if model_prune_window is not None:
-            __body["model_prune_window"] = model_prune_window
-        if model_snapshot_retention_days is not None:
-            __body["model_snapshot_retention_days"] = model_snapshot_retention_days
-        if per_partition_categorization is not None:
-            __body["per_partition_categorization"] = per_partition_categorization
         if pretty is not None:
             __query["pretty"] = pretty
-        if renormalization_window_days is not None:
-            __body["renormalization_window_days"] = renormalization_window_days
-        if results_retention_days is not None:
-            __body["results_retention_days"] = results_retention_days
+        if not __body:
+            if allow_lazy_open is not None:
+                __body["allow_lazy_open"] = allow_lazy_open
+            if analysis_limits is not None:
+                __body["analysis_limits"] = analysis_limits
+            if background_persist_interval is not None:
+                __body["background_persist_interval"] = background_persist_interval
+            if categorization_filters is not None:
+                __body["categorization_filters"] = categorization_filters
+            if custom_settings is not None:
+                __body["custom_settings"] = custom_settings
+            if daily_model_snapshot_retention_after_days is not None:
+                __body["daily_model_snapshot_retention_after_days"] = (
+                    daily_model_snapshot_retention_after_days
+                )
+            if description is not None:
+                __body["description"] = description
+            if detectors is not None:
+                __body["detectors"] = detectors
+            if groups is not None:
+                __body["groups"] = groups
+            if model_plot_config is not None:
+                __body["model_plot_config"] = model_plot_config
+            if model_prune_window is not None:
+                __body["model_prune_window"] = model_prune_window
+            if model_snapshot_retention_days is not None:
+                __body["model_snapshot_retention_days"] = model_snapshot_retention_days
+            if per_partition_categorization is not None:
+                __body["per_partition_categorization"] = per_partition_categorization
+            if renormalization_window_days is not None:
+                __body["renormalization_window_days"] = renormalization_window_days
+            if results_retention_days is not None:
+                __body["results_retention_days"] = results_retention_days
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/query_ruleset.py
+++ b/elasticsearch_serverless/_sync/client/query_ruleset.py
@@ -134,17 +134,18 @@ class QueryRulesetClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("rules",),
     )
     def put(
         self,
         *,
         ruleset_id: str,
-        rules: t.Sequence[t.Mapping[str, t.Any]],
+        rules: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a query ruleset.
@@ -157,13 +158,11 @@ class QueryRulesetClient(NamespacedClient):
         """
         if ruleset_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'ruleset_id'")
-        if rules is None:
+        if rules is None and body is None:
             raise ValueError("Empty value passed for parameter 'rules'")
         __path = f"/_query_rules/{_quote(ruleset_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if rules is not None:
-            __body["rules"] = rules
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -172,6 +171,9 @@ class QueryRulesetClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if rules is not None:
+                __body["rules"] = rules
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/search_application.py
+++ b/elasticsearch_serverless/_sync/client/search_application.py
@@ -213,7 +213,8 @@ class SearchApplicationClient(NamespacedClient):
         self,
         *,
         name: str,
-        search_application: t.Mapping[str, t.Any],
+        search_application: t.Optional[t.Mapping[str, t.Any]] = None,
+        body: t.Optional[t.Mapping[str, t.Any]] = None,
         create: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
@@ -232,8 +233,12 @@ class SearchApplicationClient(NamespacedClient):
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
-        if search_application is None:
-            raise ValueError("Empty value passed for parameter 'search_application'")
+        if search_application is None and body is None:
+            raise ValueError(
+                "Empty value passed for parameters 'search_application' and 'body', one of them should be set."
+            )
+        elif search_application is not None and body is not None:
+            raise ValueError("Cannot set both 'search_application' and 'body'")
         __path = f"/_application/search_application/{_quote(name)}"
         __query: t.Dict[str, t.Any] = {}
         if create is not None:
@@ -246,7 +251,7 @@ class SearchApplicationClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        __body = search_application
+        __body = search_application if search_application is not None else body
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -287,7 +292,7 @@ class SearchApplicationClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("params",),
         ignore_deprecated_options={"params"},
     )
     def search(
@@ -299,6 +304,7 @@ class SearchApplicationClient(NamespacedClient):
         human: t.Optional[bool] = None,
         params: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Perform a search against a search application
@@ -313,17 +319,18 @@ class SearchApplicationClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'name'")
         __path = f"/_application/search_application/{_quote(name)}/_search"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if params is not None:
+                __body["params"] = params
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/security.py
+++ b/elasticsearch_serverless/_sync/client/security.py
@@ -56,7 +56,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "name", "role_descriptors"),
     )
     def create_api_key(
         self,
@@ -72,6 +72,7 @@ class SecurityClient(NamespacedClient):
             t.Union["t.Literal['false', 'true', 'wait_for']", bool, str]
         ] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates an API key for access without requiring basic authentication.
@@ -98,25 +99,26 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
-        if name is not None:
-            __body["name"] = name
         if pretty is not None:
             __query["pretty"] = pretty
         if refresh is not None:
             __query["refresh"] = refresh
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if name is not None:
+                __body["name"] = name
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -199,7 +201,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("application", "cluster", "index"),
     )
     def has_privileges(
         self,
@@ -219,6 +221,7 @@ class SecurityClient(NamespacedClient):
         human: t.Optional[bool] = None,
         index: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Determines whether the specified user has a specified list of privileges.
@@ -234,29 +237,30 @@ class SecurityClient(NamespacedClient):
             __path = f"/_security/user/{_quote(user)}/_has_privileges"
         else:
             __path = "/_security/user/_has_privileges"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if application is not None:
-            __body["application"] = application
-        if cluster is not None:
-            __body["cluster"] = cluster
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if index is not None:
-            __body["index"] = index
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if application is not None:
+                __body["application"] = application
+            if cluster is not None:
+                __body["cluster"] = cluster
+            if index is not None:
+                __body["index"] = index
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("id", "ids", "name", "owner", "realm_name", "username"),
     )
     def invalidate_api_key(
         self,
@@ -271,6 +275,7 @@ class SecurityClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
         realm_name: t.Optional[str] = None,
         username: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Invalidates one or more API keys.
@@ -293,34 +298,43 @@ class SecurityClient(NamespacedClient):
         """
         __path = "/_security/api_key"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if id is not None:
-            __body["id"] = id
-        if ids is not None:
-            __body["ids"] = ids
-        if name is not None:
-            __body["name"] = name
-        if owner is not None:
-            __body["owner"] = owner
         if pretty is not None:
             __query["pretty"] = pretty
-        if realm_name is not None:
-            __body["realm_name"] = realm_name
-        if username is not None:
-            __body["username"] = username
+        if not __body:
+            if id is not None:
+                __body["id"] = id
+            if ids is not None:
+                __body["ids"] = ids
+            if name is not None:
+                __body["name"] = name
+            if owner is not None:
+                __body["owner"] = owner
+            if realm_name is not None:
+                __body["realm_name"] = realm_name
+            if username is not None:
+                __body["username"] = username
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "DELETE", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "aggregations",
+            "aggs",
+            "from_",
+            "query",
+            "search_after",
+            "size",
+            "sort",
+        ),
         parameter_aliases={"from": "from_"},
     )
     def query_api_keys(
@@ -347,6 +361,7 @@ class SecurityClient(NamespacedClient):
         typed_keys: t.Optional[bool] = None,
         with_limited_by: t.Optional[bool] = None,
         with_profile_uid: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Retrieves information for API keys using a subset of query DSL
@@ -391,8 +406,8 @@ class SecurityClient(NamespacedClient):
             for the API key owner principal, if it exists.
         """
         __path = "/_security/_query/api_key"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         # The 'sort' parameter with a colon can't be encoded to the body.
         if sort is not None and (
             (isinstance(sort, str) and ":" in sort)
@@ -404,34 +419,35 @@ class SecurityClient(NamespacedClient):
         ):
             __query["sort"] = sort
             sort = None
-        if aggregations is not None:
-            __body["aggregations"] = aggregations
-        if aggs is not None:
-            __body["aggs"] = aggs
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if from_ is not None:
-            __body["from"] = from_
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if search_after is not None:
-            __body["search_after"] = search_after
-        if size is not None:
-            __body["size"] = size
-        if sort is not None:
-            __body["sort"] = sort
         if typed_keys is not None:
             __query["typed_keys"] = typed_keys
         if with_limited_by is not None:
             __query["with_limited_by"] = with_limited_by
         if with_profile_uid is not None:
             __query["with_profile_uid"] = with_profile_uid
+        if not __body:
+            if aggregations is not None:
+                __body["aggregations"] = aggregations
+            if aggs is not None:
+                __body["aggs"] = aggs
+            if from_ is not None:
+                __body["from"] = from_
+            if query is not None:
+                __body["query"] = query
+            if search_after is not None:
+                __body["search_after"] = search_after
+            if size is not None:
+                __body["size"] = size
+            if sort is not None:
+                __body["sort"] = sort
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -442,7 +458,7 @@ class SecurityClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("expiration", "metadata", "role_descriptors"),
     )
     def update_api_key(
         self,
@@ -455,6 +471,7 @@ class SecurityClient(NamespacedClient):
         metadata: t.Optional[t.Mapping[str, t.Any]] = None,
         pretty: t.Optional[bool] = None,
         role_descriptors: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates attributes of an existing API key.
@@ -479,21 +496,22 @@ class SecurityClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'id'")
         __path = f"/_security/api_key/{_quote(id)}"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if expiration is not None:
-            __body["expiration"] = expiration
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
-        if metadata is not None:
-            __body["metadata"] = metadata
         if pretty is not None:
             __query["pretty"] = pretty
-        if role_descriptors is not None:
-            __body["role_descriptors"] = role_descriptors
+        if not __body:
+            if expiration is not None:
+                __body["expiration"] = expiration
+            if metadata is not None:
+                __body["metadata"] = metadata
+            if role_descriptors is not None:
+                __body["role_descriptors"] = role_descriptors
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}

--- a/elasticsearch_serverless/_sync/client/sql.py
+++ b/elasticsearch_serverless/_sync/client/sql.py
@@ -26,16 +26,17 @@ from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 class SqlClient(NamespacedClient):
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("cursor",),
     )
     def clear_cursor(
         self,
         *,
-        cursor: str,
+        cursor: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Clears the SQL cursor
@@ -44,13 +45,11 @@ class SqlClient(NamespacedClient):
 
         :param cursor: Cursor to clear.
         """
-        if cursor is None:
+        if cursor is None and body is None:
             raise ValueError("Empty value passed for parameter 'cursor'")
         __path = "/_sql/close"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -59,6 +58,9 @@ class SqlClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if cursor is not None:
+                __body["cursor"] = cursor
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
@@ -193,7 +195,24 @@ class SqlClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "catalog",
+            "columnar",
+            "cursor",
+            "fetch_size",
+            "field_multi_value_leniency",
+            "filter",
+            "index_using_frozen",
+            "keep_alive",
+            "keep_on_completion",
+            "page_timeout",
+            "params",
+            "query",
+            "request_timeout",
+            "runtime_mappings",
+            "time_zone",
+            "wait_for_completion_timeout",
+        ),
         ignore_deprecated_options={"params", "request_timeout"},
     )
     def query(
@@ -224,6 +243,7 @@ class SqlClient(NamespacedClient):
         wait_for_completion_timeout: t.Optional[
             t.Union["t.Literal[-1]", "t.Literal[0]", str]
         ] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Executes a SQL request
@@ -262,62 +282,63 @@ class SqlClient(NamespacedClient):
             the search doesn’t finish within this period, the search becomes async.
         """
         __path = "/_sql"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if catalog is not None:
-            __body["catalog"] = catalog
-        if columnar is not None:
-            __body["columnar"] = columnar
-        if cursor is not None:
-            __body["cursor"] = cursor
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if field_multi_value_leniency is not None:
-            __body["field_multi_value_leniency"] = field_multi_value_leniency
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if format is not None:
             __query["format"] = format
         if human is not None:
             __query["human"] = human
-        if index_using_frozen is not None:
-            __body["index_using_frozen"] = index_using_frozen
-        if keep_alive is not None:
-            __body["keep_alive"] = keep_alive
-        if keep_on_completion is not None:
-            __body["keep_on_completion"] = keep_on_completion
-        if page_timeout is not None:
-            __body["page_timeout"] = page_timeout
-        if params is not None:
-            __body["params"] = params
         if pretty is not None:
             __query["pretty"] = pretty
-        if query is not None:
-            __body["query"] = query
-        if request_timeout is not None:
-            __body["request_timeout"] = request_timeout
-        if runtime_mappings is not None:
-            __body["runtime_mappings"] = runtime_mappings
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
-        if wait_for_completion_timeout is not None:
-            __body["wait_for_completion_timeout"] = wait_for_completion_timeout
+        if not __body:
+            if catalog is not None:
+                __body["catalog"] = catalog
+            if columnar is not None:
+                __body["columnar"] = columnar
+            if cursor is not None:
+                __body["cursor"] = cursor
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if field_multi_value_leniency is not None:
+                __body["field_multi_value_leniency"] = field_multi_value_leniency
+            if filter is not None:
+                __body["filter"] = filter
+            if index_using_frozen is not None:
+                __body["index_using_frozen"] = index_using_frozen
+            if keep_alive is not None:
+                __body["keep_alive"] = keep_alive
+            if keep_on_completion is not None:
+                __body["keep_on_completion"] = keep_on_completion
+            if page_timeout is not None:
+                __body["page_timeout"] = page_timeout
+            if params is not None:
+                __body["params"] = params
+            if query is not None:
+                __body["query"] = query
+            if request_timeout is not None:
+                __body["request_timeout"] = request_timeout
+            if runtime_mappings is not None:
+                __body["runtime_mappings"] = runtime_mappings
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
+            if wait_for_completion_timeout is not None:
+                __body["wait_for_completion_timeout"] = wait_for_completion_timeout
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("query", "fetch_size", "filter", "time_zone"),
     )
     def translate(
         self,
         *,
-        query: str,
+        query: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         fetch_size: t.Optional[int] = None,
         filter: t.Optional[t.Mapping[str, t.Any]] = None,
@@ -325,6 +346,7 @@ class SqlClient(NamespacedClient):
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
         time_zone: t.Optional[str] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Translates SQL into Elasticsearch queries
@@ -336,27 +358,28 @@ class SqlClient(NamespacedClient):
         :param filter: Elasticsearch query DSL for additional filtering.
         :param time_zone: ISO-8601 time zone ID for the search.
         """
-        if query is None:
+        if query is None and body is None:
             raise ValueError("Empty value passed for parameter 'query'")
         __path = "/_sql/translate"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if query is not None:
-            __body["query"] = query
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
-        if fetch_size is not None:
-            __body["fetch_size"] = fetch_size
-        if filter is not None:
-            __body["filter"] = filter
         if filter_path is not None:
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
-        if time_zone is not None:
-            __body["time_zone"] = time_zone
+        if not __body:
+            if query is not None:
+                __body["query"] = query
+            if fetch_size is not None:
+                __body["fetch_size"] = fetch_size
+            if filter is not None:
+                __body["filter"] = filter
+            if time_zone is not None:
+                __body["time_zone"] = time_zone
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/synonyms.py
+++ b/elasticsearch_serverless/_sync/client/synonyms.py
@@ -220,17 +220,18 @@ class SynonymsClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms_set",),
     )
     def put_synonym(
         self,
         *,
         id: str,
-        synonyms_set: t.Sequence[t.Mapping[str, t.Any]],
+        synonyms_set: t.Optional[t.Sequence[t.Mapping[str, t.Any]]] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonyms set
@@ -242,13 +243,11 @@ class SynonymsClient(NamespacedClient):
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
-        if synonyms_set is None:
+        if synonyms_set is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms_set'")
         __path = f"/_synonyms/{_quote(id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms_set is not None:
-            __body["synonyms_set"] = synonyms_set
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -257,24 +256,28 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms_set is not None:
+                __body["synonyms_set"] = synonyms_set
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=("synonyms",),
     )
     def put_synonym_rule(
         self,
         *,
         set_id: str,
         rule_id: str,
-        synonyms: str,
+        synonyms: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         pretty: t.Optional[bool] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Creates or updates a synonym rule in a synonym set
@@ -289,13 +292,11 @@ class SynonymsClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'set_id'")
         if rule_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'rule_id'")
-        if synonyms is None:
+        if synonyms is None and body is None:
             raise ValueError("Empty value passed for parameter 'synonyms'")
         __path = f"/_synonyms/{_quote(set_id)}/{_quote(rule_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if synonyms is not None:
-            __body["synonyms"] = synonyms
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
@@ -304,6 +305,9 @@ class SynonymsClient(NamespacedClient):
             __query["human"] = human
         if pretty is not None:
             __query["pretty"] = pretty
+        if not __body:
+            if synonyms is not None:
+                __body["synonyms"] = synonyms
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/_sync/client/transform.py
+++ b/elasticsearch_serverless/_sync/client/transform.py
@@ -196,7 +196,17 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "latest",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
     )
     def preview_transform(
         self,
@@ -216,6 +226,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Previews a transform.
@@ -248,36 +259,37 @@ class TransformClient(NamespacedClient):
             __path = f"/_transform/{_quote(transform_id)}/_preview"
         else:
             __path = "/_transform/_preview"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         if not __body:
             __body = None  # type: ignore[assignment]
         __headers = {"accept": "application/json"}
@@ -288,15 +300,26 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "dest",
+            "source",
+            "description",
+            "frequency",
+            "latest",
+            "meta",
+            "pivot",
+            "retention_policy",
+            "settings",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def put_transform(
         self,
         *,
         transform_id: str,
-        dest: t.Mapping[str, t.Any],
-        source: t.Mapping[str, t.Any],
+        dest: t.Optional[t.Mapping[str, t.Any]] = None,
+        source: t.Optional[t.Mapping[str, t.Any]] = None,
         defer_validation: t.Optional[bool] = None,
         description: t.Optional[str] = None,
         error_trace: t.Optional[bool] = None,
@@ -311,6 +334,7 @@ class TransformClient(NamespacedClient):
         settings: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Instantiates a transform.
@@ -349,45 +373,46 @@ class TransformClient(NamespacedClient):
         """
         if transform_id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'transform_id'")
-        if dest is None:
+        if dest is None and body is None:
             raise ValueError("Empty value passed for parameter 'dest'")
-        if source is None:
+        if source is None and body is None:
             raise ValueError("Empty value passed for parameter 'source'")
         __path = f"/_transform/{_quote(transform_id)}"
-        __body: t.Dict[str, t.Any] = {}
         __query: t.Dict[str, t.Any] = {}
-        if dest is not None:
-            __body["dest"] = dest
-        if source is not None:
-            __body["source"] = source
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if latest is not None:
-            __body["latest"] = latest
-        if meta is not None:
-            __body["_meta"] = meta
-        if pivot is not None:
-            __body["pivot"] = pivot
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if dest is not None:
+                __body["dest"] = dest
+            if source is not None:
+                __body["source"] = source
+            if description is not None:
+                __body["description"] = description
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if latest is not None:
+                __body["latest"] = latest
+            if meta is not None:
+                __body["_meta"] = meta
+            if pivot is not None:
+                __body["pivot"] = pivot
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "PUT", __path, params=__query, headers=__headers, body=__body
@@ -590,7 +615,16 @@ class TransformClient(NamespacedClient):
         )
 
     @_rewrite_parameters(
-        body_fields=True,
+        body_fields=(
+            "description",
+            "dest",
+            "frequency",
+            "meta",
+            "retention_policy",
+            "settings",
+            "source",
+            "sync",
+        ),
         parameter_aliases={"_meta": "meta"},
     )
     def update_transform(
@@ -611,6 +645,7 @@ class TransformClient(NamespacedClient):
         source: t.Optional[t.Mapping[str, t.Any]] = None,
         sync: t.Optional[t.Mapping[str, t.Any]] = None,
         timeout: t.Optional[t.Union["t.Literal[-1]", "t.Literal[0]", str]] = None,
+        body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
         Updates certain properties of a transform.
@@ -640,35 +675,36 @@ class TransformClient(NamespacedClient):
             raise ValueError("Empty value passed for parameter 'transform_id'")
         __path = f"/_transform/{_quote(transform_id)}/_update"
         __query: t.Dict[str, t.Any] = {}
-        __body: t.Dict[str, t.Any] = {}
+        __body: t.Dict[str, t.Any] = body if body is not None else {}
         if defer_validation is not None:
             __query["defer_validation"] = defer_validation
-        if description is not None:
-            __body["description"] = description
-        if dest is not None:
-            __body["dest"] = dest
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if filter_path is not None:
             __query["filter_path"] = filter_path
-        if frequency is not None:
-            __body["frequency"] = frequency
         if human is not None:
             __query["human"] = human
-        if meta is not None:
-            __body["_meta"] = meta
         if pretty is not None:
             __query["pretty"] = pretty
-        if retention_policy is not None:
-            __body["retention_policy"] = retention_policy
-        if settings is not None:
-            __body["settings"] = settings
-        if source is not None:
-            __body["source"] = source
-        if sync is not None:
-            __body["sync"] = sync
         if timeout is not None:
             __query["timeout"] = timeout
+        if not __body:
+            if description is not None:
+                __body["description"] = description
+            if dest is not None:
+                __body["dest"] = dest
+            if frequency is not None:
+                __body["frequency"] = frequency
+            if meta is not None:
+                __body["_meta"] = meta
+            if retention_policy is not None:
+                __body["retention_policy"] = retention_policy
+            if settings is not None:
+                __body["settings"] = settings
+            if source is not None:
+                __body["source"] = source
+            if sync is not None:
+                __body["sync"] = sync
         __headers = {"accept": "application/json", "content-type": "application/json"}
         return self.perform_request(  # type: ignore[return-value]
             "POST", __path, params=__query, headers=__headers, body=__body

--- a/elasticsearch_serverless/helpers/actions.py
+++ b/elasticsearch_serverless/helpers/actions.py
@@ -707,7 +707,7 @@ def scan(
         search_kwargs = kwargs.copy()
         search_kwargs["scroll"] = scroll
         search_kwargs["size"] = size
-        resp = client.search(body=query, **search_kwargs)  # type: ignore[call-arg]
+        resp = client.search(body=query, **search_kwargs)
 
     scroll_id = resp.get("_scroll_id")
     scroll_transport_kwargs = pop_transport_kwargs(scroll_kwargs)


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-py/pull/2383 and https://github.com/elastic/elasticsearch-py/pull/2427 to serverless. The "human changes" are in:

 * elasticsearch_serverless/_sync/client/utils.py
 * elasticsearch_serverless/_async/helpers.py
 * elasticsearch_serverless/helpers/actions.py
 * test_elasticsearch_serverless/test_client/test_rewrite_parameters.py

They are copy/pasted from the stack client.