### PR TITLE
Fix pytest warning

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/conftest.py
+++ b/test_elasticsearch_serverless/test_async/test_server/conftest.py
@@ -26,9 +26,7 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest_asyncio.fixture(scope="function")
-@pytest.mark.usefixtures("sync_client")
 async def async_client(elasticsearch_url, elasticsearch_api_key):
-    # 'sync_client' fixture is used for the guaranteed wipe_cluster() call.
 
     if not hasattr(elasticsearch_serverless, "AsyncElasticsearch"):
         pytest.skip("test requires 'AsyncElasticsearch' and aiohttp to be installed")


### PR DESCRIPTION
Applying `pytest.mark.usefixtures` on a pytest fixture does not have any effect, see https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function. The idea was to call `wipe_cluster`, but we do it explicitly now anyways.

Relates https://github.com/elastic/elasticsearch-py/pull/2577