### PR TITLE
Switch to pytest_asyncio.fixture

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import pytest_asyncio
 from elastic_transport import ApiResponseMeta, ObjectApiResponse
 
 from elasticsearch_serverless import helpers
@@ -448,7 +449,7 @@ class MockResponse:
         return self().__await__()
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def scan_teardown(async_client):
     yield
     await async_client.clear_scroll(scroll_id="_all")
@@ -859,7 +860,7 @@ async def test_scan_from_keyword_is_aliased(async_client, scan_kwargs):
         assert "from" not in search_mock.call_args[1]
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def reindex_setup(async_client):
     bulk = []
     for x in range(100):
@@ -941,7 +942,7 @@ class TestReindex(object):
         )["_source"]
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def parent_reindex_setup(async_client):
     body = {
         "mappings": {
@@ -1001,7 +1002,7 @@ class TestParentChildReindex:
         } == q
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def reindex_data_stream_setup(async_client):
     dt = datetime.now(tz=timezone.utc)
     bulk = []

--- a/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import pytest
+import pytest_asyncio
 
 from elasticsearch_serverless import AsyncElasticsearch, RequestError
 
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def mvt_setup(async_client):
     await async_client.indices.create(
         index="museums",

--- a/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
@@ -25,6 +25,7 @@ import json
 import warnings
 
 import pytest
+import pytest_asyncio
 
 from elasticsearch_serverless import ElasticsearchWarning, RequestError
 
@@ -237,7 +238,7 @@ class AsyncYamlRunner(YamlRunner):
         return name in XPACK_FEATURES
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 def async_runner(async_client):
     return AsyncYamlRunner(async_client)
 


### PR DESCRIPTION
This is required now that strict mode is the default.

Ports https://github.com/elastic/elasticsearch-py/pull/2276 to serverless.