### PR TITLE
Fix mapbox tests

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
@@ -346,9 +346,7 @@ class TestBulk(object):
         assert "42" == error["index"]["_id"]
         assert "i" == error["index"]["_index"]
         print(error["index"]["error"])
-        assert "MapperParsingException" in repr(
-            error["index"]["error"]
-        ) or "mapper_parsing_exception" in repr(error["index"]["error"])
+        assert error["index"]["error"]["type"] == "document_parsing_exception"
 
     async def test_error_is_raised(self, async_client):
         await async_client.indices.create(

--- a/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
@@ -73,9 +73,8 @@ async def mvt_setup(async_client):
     )
 
 
-async def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup):
-    client = AsyncElasticsearch(elasticsearch_url)
-    await client.search_mvt(
+async def test_mapbox_vector_tile_error(async_client, mvt_setup):
+    await async_client.search_mvt(
         index="museums",
         zoom=13,
         x=4207,
@@ -84,7 +83,7 @@ async def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup):
     )
 
     with pytest.raises(RequestError) as e:
-        await client.search_mvt(
+        await async_client.search_mvt(
             index="museums",
             zoom=-100,
             x=4207,
@@ -113,15 +112,13 @@ async def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup):
     }
 
 
-async def test_mapbox_vector_tile_response(elasticsearch_url, mvt_setup):
+async def test_mapbox_vector_tile_response(async_client, mvt_setup):
     try:
         import mapbox_vector_tile
     except ImportError:
         return pytest.skip("Requires the 'mapbox-vector-tile' package")
 
-    client = AsyncElasticsearch(elasticsearch_url)
-
-    resp = await client.search_mvt(
+    resp = await async_client.search_mvt(
         index="museums",
         zoom=13,
         x=4207,

--- a/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_mapbox_vector_tile.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from elasticsearch_serverless import AsyncElasticsearch, RequestError
+from elasticsearch_serverless import RequestError
 
 pytestmark = pytest.mark.asyncio
 

--- a/test_elasticsearch_serverless/test_server/test_helpers.py
+++ b/test_elasticsearch_serverless/test_server/test_helpers.py
@@ -338,9 +338,7 @@ def test_errors_are_reported_correctly(sync_client):
     assert "42" == error["index"]["_id"]
     assert "i" == error["index"]["_index"]
     print(error["index"]["error"])
-    assert "MapperParsingException" in repr(
-        error["index"]["error"]
-    ) or "mapper_parsing_exception" in repr(error["index"]["error"])
+    assert error["index"]["error"]["type"] == "document_parsing_exception"
 
 
 def test_error_is_raised(sync_client):

--- a/test_elasticsearch_serverless/test_server/test_mapbox_vector_tile.py
+++ b/test_elasticsearch_serverless/test_server/test_mapbox_vector_tile.py
@@ -67,13 +67,12 @@ def mvt_setup(sync_client):
                 "included": True,
             },
         ],
+        refresh=True,
     )
 
 
-@pytest.mark.parametrize("node_class", ["urllib3", "requests"])
-def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup, node_class):
-    client = Elasticsearch(elasticsearch_url, node_class=node_class)
-    client.search_mvt(
+def test_mapbox_vector_tile_error(sync_client, mvt_setup):
+    sync_client.search_mvt(
         index="museums",
         zoom=13,
         x=4207,
@@ -82,7 +81,7 @@ def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup, node_class):
     )
 
     with pytest.raises(RequestError) as e:
-        client.search_mvt(
+        sync_client.search_mvt(
             index="museums",
             zoom=-100,
             x=4207,
@@ -111,16 +110,13 @@ def test_mapbox_vector_tile_error(elasticsearch_url, mvt_setup, node_class):
     }
 
 
-@pytest.mark.parametrize("node_class", ["urllib3", "requests"])
-def test_mapbox_vector_tile_response(elasticsearch_url, mvt_setup, node_class):
+def test_mapbox_vector_tile_response(sync_client, mvt_setup):
     try:
         import mapbox_vector_tile
     except ImportError:
         return pytest.skip("Requires the 'mapbox-vector-tile' package")
 
-    client = Elasticsearch(elasticsearch_url, node_class=node_class)
-
-    resp = client.search_mvt(
+    resp = sync_client.search_mvt(
         index="museums",
         zoom=13,
         x=4207,

--- a/test_elasticsearch_serverless/test_server/test_mapbox_vector_tile.py
+++ b/test_elasticsearch_serverless/test_server/test_mapbox_vector_tile.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from elasticsearch_serverless import Elasticsearch, RequestError
+from elasticsearch_serverless import RequestError
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Using `elasticsearch_url` does not work in serverless as API key authentication is required. Also, `node_class` parametrization does not make sense, we parametrize at the CI job level. And finally, the sync case was missing a refresh.

Depends on https://github.com/elastic/elasticsearch-serverless-python/pull/43
Relates https://github.com/elastic/elasticsearch-py/pull/2580