### PR TITLE
Fix test_bulk_works_with_bytestring_body

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/test_clients.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_clients.py
@@ -51,7 +51,21 @@ async def test_bulk_works_with_bytestring_body(async_client):
     docs = (
         b'{ "index" : { "_index" : "bulk_test_index", "_id" : "2" } }\n{"answer": 42}'
     )
-    response = await async_client.bulk(body=docs)
+    resp = await async_client.bulk(body=docs)
 
-    assert response["errors"] is False
-    assert len(response["items"]) == 1
+    assert resp["errors"] is False
+    assert len(resp["items"]) == 1
+
+    # Pop inconsistent items before asserting
+    resp["items"][0]["index"].pop("_id")
+    resp["items"][0]["index"].pop("_version")
+    resp["items"][0]["index"].pop("_shards")
+    assert resp["items"][0] == {
+        "index": {
+            "_index": "bulk_test_index",
+            "result": "created",
+            "_seq_no": 0,
+            "_primary_term": 1,
+            "status": 201,
+        }
+    }

--- a/test_elasticsearch_serverless/test_server/test_clients.py
+++ b/test_elasticsearch_serverless/test_server/test_clients.py
@@ -55,11 +55,11 @@ def test_bulk_works_with_bytestring_body(sync_client):
     # Pop inconsistent items before asserting
     resp["items"][0]["index"].pop("_id")
     resp["items"][0]["index"].pop("_version")
+    resp["items"][0]["index"].pop("_shards")
     assert resp["items"][0] == {
         "index": {
             "_index": "bulk_test_index",
             "result": "created",
-            "_shards": {"total": 2, "successful": 1, "failed": 0},
             "_seq_no": 0,
             "_primary_term": 1,
             "status": 201,


### PR DESCRIPTION
There's no guarantee on the number of successful shards, even it it turned out to be predictable outside serverless in practice.