### PR TITLE
Fix data stream creation refresh

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_helpers.py
@@ -1024,7 +1024,7 @@ async def reindex_data_stream_setup(async_client):
             "data_stream": {},
         },
     )
-    await async_client.indices.create_data_stream(name="py-test-stream", refresh=True)
+    await async_client.indices.create_data_stream(name="py-test-stream")
     yield
 
 


### PR DESCRIPTION
There's no reason to refresh after creating an index or data stream, as long as it was acknowledged. If it's not acknowledged, I would expect a timeout. (And we do have timeouts that need to be fixed, by the way.)