### PR TITLE
Handle clients-tests requires section

### DIFF
--- a/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
@@ -130,7 +130,9 @@ class AsyncYamlRunner(YamlRunner):
             headers.pop("Authorization")
 
         method, args = list(action.items())[0]
-        args["headers"] = headers
+
+        if headers:
+            args["headers"] = headers
 
         # locate api endpoint
         for m in method.split("."):

--- a/test_elasticsearch_serverless/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch_serverless/test_server/test_rest_api_spec.py
@@ -565,9 +565,12 @@ try:
             yaml.load_all(package_zip.read(yaml_file), Loader=NoDatesSafeLoader)
         )
 
-        # Each file may have a "test" named 'setup' or 'teardown',
-        # these sets of steps should be run at the beginning and end
-        # of every other test within the file so we do one pass to capture those.
+        # Each file has a `requires` section with `serverless` and `stack`
+        # boolean entries indicating whether the test should run with
+        # serverless, stack or both. Additionally, each file may have a section
+        # named 'setup' or 'teardown', these sets of steps should be run at the
+        # beginning and end of every other test within the file so we do one
+        # pass to capture those.
         requires = setup_steps = teardown_steps = None
         test_numbers_and_steps = []
         test_number = 0

--- a/test_elasticsearch_serverless/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch_serverless/test_server/test_rest_api_spec.py
@@ -568,19 +568,24 @@ try:
         # Each file may have a "test" named 'setup' or 'teardown',
         # these sets of steps should be run at the beginning and end
         # of every other test within the file so we do one pass to capture those.
-        setup_steps = teardown_steps = None
+        requires = setup_steps = teardown_steps = None
         test_numbers_and_steps = []
         test_number = 0
 
         for yaml_test in yaml_tests:
             test_name, test_step = yaml_test.popitem()
-            if test_name == "setup":
+            if test_name == "requires":
+                requires = test_step
+            elif test_name == "setup":
                 setup_steps = test_step
             elif test_name == "teardown":
                 teardown_steps = test_step
             else:
                 test_numbers_and_steps.append((test_number, test_step))
                 test_number += 1
+
+        if not requires["serverless"]:
+            continue
 
         # Now we combine setup, teardown, and test_steps into
         # a set of pytest.param() instances


### PR DESCRIPTION
Here's an example YAML file https://github.com/elastic/elasticsearch-clients-tests/blob/main/tests/ping/ping.yml. The "requires" sections were mistaken for actual tests to run until now.