### PR TITLE
Mark failing tests with pytest.xfail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ packages = ["elasticsearch_serverless"]
 [tool.pytest]
 junit_family = "legacy"
 addopts = "-vvv -p no:logging --cov-report=term-missing --cov=elasticsearch_serverless --cov-config=.pyproject.toml"
+xfail_strict=true
 
 [tool.isort]
 profile = "black"

--- a/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
+++ b/test_elasticsearch_serverless/test_async/test_server/test_rest_api_spec.py
@@ -249,7 +249,7 @@ if RUN_ASYNC_REST_API_TESTS:
 
     @pytest.mark.parametrize("test_spec", YAML_TEST_SPECS)
     async def test_rest_api_spec(test_spec, async_runner):
-        if test_spec.get("skip", False):
-            pytest.skip("Manually skipped in 'SKIP_TESTS'")
+        if test_spec.get("fail", False):
+            pytest.xfail("Manually marked as failing in 'FAILING_TESTS'")
         async_runner.use_spec(test_spec)
         await async_runner.run()


### PR DESCRIPTION
The benefit of using xfail instead of skip is that if the test starts to pass, we'll be notified.