### PR TITLE
Remove redundant/deprecated `np.float_` use to fix NumPy 2.0 compat

### DIFF
--- a/elasticsearch_serverless/serializer.py
+++ b/elasticsearch_serverless/serializer.py
@@ -157,7 +157,6 @@ def _attempt_serialize_numpy(data: Any) -> Tuple[bool, Any]:
         elif isinstance(
             data,
             (
-                np.float_,
                 np.float16,
                 np.float32,
                 np.float64,

--- a/test_elasticsearch_serverless/test_serializer.py
+++ b/test_elasticsearch_serverless/test_serializer.py
@@ -90,7 +90,6 @@ def test_serializes_numpy_integers():
 def test_serializes_numpy_floats():
     ser = JSONSerializer()
     for np_type in (
-        np.float_,
         np.float32,
         np.float64,
     ):


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-py/pull/2551