### PR TITLE
Fix teardown of projects in CI

### DIFF
--- a/.buildkite/generatesteps.py
+++ b/.buildkite/generatesteps.py
@@ -44,7 +44,7 @@ def benchmark_to_steps(python, connection_class, nox_session):
                         "EC_PROJECT_PREFIX": f"esv-client-python-{nox_session}-{python}-{connection_class}",
                     },
                     "command": ".buildkite/teardown-tests",
-                    "depends_on": f"run_{python.replace('.', '_')}_{connection_class}",
+                    "depends_on": f"run_{python.replace('.', '_')}_{connection_class}_{nox_session}",
                     "allow_dependency_failure": True,
                 },
             ],


### PR DESCRIPTION
Unlike https://buildkite.com/elastic/elasticsearch-serverless-python-rest-tests/builds/751 (without the fix), https://buildkite.com/elastic/elasticsearch-serverless-python-rest-tests/builds/752 does not report "unresolved step dependencies".

This was causing projects to not be terminated. And then we reached 100 projects in QA, and projects could not even start.