### PR TITLE
Updated build-dists.py to work with pyproject.toml

### DIFF
--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -50,7 +50,7 @@ def run(*argv, expect_exit_code=0):
         else:
             os.chdir(tmp_dir)
 
-        cmd = " ".join(shlex.quote(x) for x in argv)
+        cmd = shlex.join(argv)
         print("$ " + cmd)
         exit_code = os.system(cmd)
         if exit_code != expect_exit_code:
@@ -123,6 +123,7 @@ def test_dist(dist):
                 "--strict",
                 "--install-types",
                 "--non-interactive",
+                "--ignore-missing-imports",
                 os.path.join(
                     base_dir, "test_elasticsearch_serverless/test_types/async_types.py"
                 ),
@@ -148,6 +149,7 @@ def test_dist(dist):
                 "--strict",
                 "--install-types",
                 "--non-interactive",
+                "--ignore-missing-imports",
                 os.path.join(
                     base_dir, "test_elasticsearch_serverless/test_types/sync_types.py"
                 ),


### PR DESCRIPTION
While trying to automate the release of 0.4.0 I noticed that the build-dists.py script is out of date, as it was not updated when the package changed from setup.py to pyproject.toml.

This PR has some changes and simplifications that enabled me to do the release. Open to discuss if we can simplify it even more.