### PR TITLE
Run tests only once per day

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -41,6 +41,6 @@ spec:
         build_branches: true
       cancel_intermediate_builds: false
       schedules:
-        main_semi_daily:
+        main_daily:
           branch: 'main'
-          cronline: '0 */12 * * *'
+          cronline: '0 2 * * *'


### PR DESCRIPTION
Every 12 hours is too much, especially when they are failing! Also, let's use 2AM UTC to avoid running tests at midnight UTC, which is often busy.