### PR TITLE
Type check against opentelemetry-api

### DIFF
--- a/elasticsearch_serverless/_otel.py
+++ b/elasticsearch_serverless/_otel.py
@@ -106,7 +106,7 @@ class OpenTelemetry:
 
     @contextlib.contextmanager
     def use_span(self, span: OpenTelemetrySpan) -> Generator[None, None, None]:
-        if not self.enabled or self.tracer is None:
+        if not self.enabled or self.tracer is None or span.otel_span is None:
             yield
             return
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,14 +78,16 @@ def format(session):
 
 @nox.session()
 def lint(session):
-    session.install("flake8", "black~=24.0", "mypy", "isort", "types-requests")
+    session.install(
+        "flake8", "black~=24.0", "mypy", "isort", "types-requests", "opentelemetry-api"
+    )
 
     session.run("isort", "--check", "--profile=black", *SOURCE_FILES)
     session.run("black", "--check", *SOURCE_FILES)
     session.run("flake8", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
 
-    session.install(".[async,requests,orjson,pyarrow]", env=INSTALL_ENV)
+    session.install(".[dev]", env=INSTALL_ENV)
 
     # Run mypy on the package and then the type examples separately for
     # the two different mypy use-cases, ourselves and our users.


### PR DESCRIPTION
Right now, `utils/build-dists.py` calls mypy with opentelemetry-api installed, which was failing. This change reduces the diff, but I'm wondering if `utils/build-dists.py` should not use `nox -s lint` instead.