### PR TITLE
Auto-generated code for main

### DIFF
--- a/elasticsearch_serverless/_async/client/__init__.py
+++ b/elasticsearch_serverless/_async/client/__init__.py
@@ -702,7 +702,7 @@ class AsyncElasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns number of documents matching a query.
+        Count search results. Get the number of documents matching a query.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
 
@@ -2624,6 +2624,7 @@ class AsyncElasticsearch(BaseClient):
         *,
         index: t.Union[str, t.Sequence[str]],
         keep_alive: t.Union[str, t.Literal[-1], t.Literal[0]],
+        allow_partial_search_results: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
             t.Union[
@@ -2658,6 +2659,10 @@ class AsyncElasticsearch(BaseClient):
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
         :param keep_alive: Extends the time to live of the corresponding point in time.
+        :param allow_partial_search_results: If `false`, creating a point in time request
+            when a shard is missing or unavailable will throw an exception. If `true`,
+            the point in time will contain all the shards that are available at the time
+            of the request.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
@@ -2680,6 +2685,8 @@ class AsyncElasticsearch(BaseClient):
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
+        if allow_partial_search_results is not None:
+            __query["allow_partial_search_results"] = allow_partial_search_results
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:

--- a/elasticsearch_serverless/_async/client/async_search.py
+++ b/elasticsearch_serverless/_async/client/async_search.py
@@ -145,6 +145,7 @@ class AsyncSearchClient(NamespacedClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -156,6 +157,9 @@ class AsyncSearchClient(NamespacedClient):
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :param id: A unique identifier for the async search.
+        :param keep_alive: Specifies how long the async search needs to be available.
+            Ongoing async searches and any saved search results are deleted after this
+            period.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -168,6 +172,8 @@ class AsyncSearchClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if keep_alive is not None:
+            __query["keep_alive"] = keep_alive
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -258,7 +264,6 @@ class AsyncSearchClient(NamespacedClient):
         ignore_throttled: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         indices_boost: t.Optional[t.Sequence[t.Mapping[str, float]]] = None,
-        keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         keep_on_completion: t.Optional[bool] = None,
         knn: t.Optional[
             t.Union[t.Mapping[str, t.Any], t.Sequence[t.Mapping[str, t.Any]]]
@@ -268,7 +273,6 @@ class AsyncSearchClient(NamespacedClient):
         min_score: t.Optional[float] = None,
         pit: t.Optional[t.Mapping[str, t.Any]] = None,
         post_filter: t.Optional[t.Mapping[str, t.Any]] = None,
-        pre_filter_shard_size: t.Optional[int] = None,
         preference: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
@@ -282,7 +286,6 @@ class AsyncSearchClient(NamespacedClient):
         routing: t.Optional[str] = None,
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
-        scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
             t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
         ] = None,
@@ -375,9 +378,6 @@ class AsyncSearchClient(NamespacedClient):
         :param ignore_unavailable: Whether specified concrete indices should be ignored
             when unavailable (missing or closed)
         :param indices_boost: Boosts the _score of documents from specified indices.
-        :param keep_alive: Specifies how long the async search needs to be available.
-            Ongoing async searches and any saved search results are deleted after this
-            period.
         :param keep_on_completion: If `true`, results are stored for later retrieval
             when the search completes within the `wait_for_completion_timeout`.
         :param knn: Defines the approximate kNN search to run.
@@ -392,10 +392,6 @@ class AsyncSearchClient(NamespacedClient):
         :param pit: Limits the search to a point in time (PIT). If you provide a PIT,
             you cannot specify an <index> in the request path.
         :param post_filter:
-        :param pre_filter_shard_size: The default value cannot be changed, which enforces
-            the execution of a pre-filter roundtrip to retrieve statistics from each
-            shard so that the ones that surely don’t hold any document matching the query
-            get skipped.
         :param preference: Specify the node or shard the operation should be performed
             on (default: random)
         :param profile:
@@ -404,13 +400,13 @@ class AsyncSearchClient(NamespacedClient):
         :param request_cache: Specify if request cache should be used for this request
             or not, defaults to true
         :param rescore:
-        :param rest_total_hits_as_int:
+        :param rest_total_hits_as_int: Indicates whether hits.total should be rendered
+            as an integer or an object in the rest search response
         :param routing: A comma-separated list of specific routing values
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
         :param script_fields: Retrieve a script evaluation (based on different fields)
             for each hit.
-        :param scroll:
         :param search_after:
         :param search_type: Search operation type
         :param seq_no_primary_term: If true, returns sequence number and primary term
@@ -507,16 +503,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
-        if pre_filter_shard_size is not None:
-            __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
@@ -529,8 +521,6 @@ class AsyncSearchClient(NamespacedClient):
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if scroll is not None:
-            __query["scroll"] = scroll
         if search_type is not None:
             __query["search_type"] = search_type
         if source_excludes is not None:

--- a/elasticsearch_serverless/_async/client/cat.py
+++ b/elasticsearch_serverless/_async/client/cat.py
@@ -1551,7 +1551,7 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get transforms. Returns configuration and usage information about transforms.
+        Get transform information. Get configuration and usage information about transforms.
         CAT APIs are only intended for human consumption using the Kibana console or
         command line. They are not intended for use by applications. For application
         consumption, use the get transform statistics API.

--- a/elasticsearch_serverless/_async/client/enrich.py
+++ b/elasticsearch_serverless/_async/client/enrich.py
@@ -77,7 +77,7 @@ class EnrichClient(NamespacedClient):
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates the enrich index for an existing enrich policy.
+        Run an enrich policy. Create the enrich index for an existing enrich policy.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/eql.py
+++ b/elasticsearch_serverless/_async/client/eql.py
@@ -36,8 +36,8 @@ class EqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes an async EQL search or a stored synchronous EQL search. The API also
-        deletes results for the search.
+        Delete an async EQL search. Delete an async EQL search or a stored synchronous
+        EQL search. The API also deletes results for the search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
@@ -83,8 +83,8 @@ class EqlClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status and available results for an async EQL search or a
-        stored synchronous EQL search.
+        Get async EQL search results. Get the current status and available results for
+        an async EQL search or a stored synchronous EQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html>`_
 
@@ -134,8 +134,8 @@ class EqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status for an async EQL search or a stored synchronous EQL
-        search without returning results.
+        Get the async EQL status. Get the current status for an async EQL search or a
+        stored synchronous EQL search without returning results.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-status-api.html>`_
 
@@ -225,7 +225,9 @@ class EqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns results matching a query expressed in Event Query Language (EQL)
+        Get EQL search results. Returns search results for an Event Query Language (EQL)
+        query. EQL assumes each document in a data stream or index corresponds to an
+        event.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/esql.py
+++ b/elasticsearch_serverless/_async/client/esql.py
@@ -68,7 +68,8 @@ class EsqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes an ES|QL request
+        Run an ES|QL query. Get search results for an ES|QL (Elasticsearch query language)
+        query.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-rest.html>`_
 

--- a/elasticsearch_serverless/_async/client/graph.py
+++ b/elasticsearch_serverless/_async/client/graph.py
@@ -45,8 +45,14 @@ class GraphClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Extracts and summarizes information about the documents and terms in an Elasticsearch
-        data stream or index.
+        Explore graph analytics. Extract and summarize information about the documents
+        and terms in an Elasticsearch data stream or index. The easiest way to understand
+        the behavior of this API is to use the Graph UI to explore connections. An initial
+        request to the `_explore` API contains a seed query that identifies the documents
+        of interest and specifies the fields that define the vertices and connections
+        you want to include in the graph. Subsequent requests enable you to spider out
+        from one more vertices of interest. You can exclude vertices that have already
+        been returned.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/indices.py
+++ b/elasticsearch_serverless/_async/client/indices.py
@@ -701,6 +701,7 @@ class IndicesClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> HeadApiResponse:
         """
@@ -721,6 +722,9 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param ignore_unavailable: If `false`, requests that include a missing data stream
             or index in the target indices or data streams return an error.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -746,6 +750,8 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -770,7 +776,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> HeadApiResponse:
         """
-        Returns information about whether a particular index template exists.
+        Check index templates. Check whether index templates exist.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html>`_
 
@@ -974,6 +980,7 @@ class IndicesClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -995,6 +1002,9 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
@@ -1022,6 +1032,8 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -2208,8 +2220,8 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Resolves the specified name(s) and/or index patterns for indices, aliases, and
-        data streams. Multiple patterns and remote clusters are supported.
+        Resolve indices. Resolve the names and/or index patterns for indices, aliases,
+        and data streams. Multiple patterns and remote clusters are supported.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/inference.py
+++ b/elasticsearch_serverless/_async/client/inference.py
@@ -20,19 +20,12 @@ import typing as t
 from elastic_transport import ObjectApiResponse
 
 from ._base import NamespacedClient
-from .utils import (
-    SKIP_IN_PATH,
-    Stability,
-    _quote,
-    _rewrite_parameters,
-    _stability_warning,
-)
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 
 class InferenceClient(NamespacedClient):
 
     @_rewrite_parameters()
-    @_stability_warning(Stability.EXPERIMENTAL)
     async def delete(
         self,
         *,
@@ -100,7 +93,6 @@ class InferenceClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
-    @_stability_warning(Stability.EXPERIMENTAL)
     async def get(
         self,
         *,
@@ -159,7 +151,6 @@ class InferenceClient(NamespacedClient):
     @_rewrite_parameters(
         body_fields=("input", "query", "task_settings"),
     )
-    @_stability_warning(Stability.EXPERIMENTAL)
     async def inference(
         self,
         *,
@@ -246,7 +237,6 @@ class InferenceClient(NamespacedClient):
     @_rewrite_parameters(
         body_name="inference_config",
     )
-    @_stability_warning(Stability.EXPERIMENTAL)
     async def put(
         self,
         *,

--- a/elasticsearch_serverless/_async/client/ingest.py
+++ b/elasticsearch_serverless/_async/client/ingest.py
@@ -38,7 +38,7 @@ class IngestClient(NamespacedClient):
         timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes one or more existing ingest pipeline.
+        Delete pipelines. Delete one or more ingest pipelines.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
 
@@ -90,8 +90,8 @@ class IngestClient(NamespacedClient):
         summary: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns information about one or more ingest pipelines. This API returns a local
-        reference of the pipeline.
+        Get pipelines. Get information about one or more ingest pipelines. This API returns
+        a local reference of the pipeline.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
 
@@ -142,10 +142,10 @@ class IngestClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Extracts structured fields out of a single text field within a document. You
-        choose which field to extract matched fields from, as well as the grok pattern
-        you expect will match. A grok pattern is like a regular expression that supports
-        aliased expressions that can be reused.
+        Run a grok processor. Extract structured fields out of a single text field within
+        a document. You must choose which field to extract matched fields from, as well
+        as the grok pattern you expect will match. A grok pattern is like a regular expression
+        that supports aliased expressions that can be reused.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html>`_
         """
@@ -201,8 +201,7 @@ class IngestClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates an ingest pipeline. Changes made using this API take effect
-        immediately.
+        Create or update a pipeline. Changes made using this API take effect immediately.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html>`_
 
@@ -294,7 +293,9 @@ class IngestClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes an ingest pipeline against a set of provided documents.
+        Simulate a pipeline. Run an ingest pipeline against a set of provided documents.
+        You can either specify an existing pipeline to use with the provided documents
+        or supply a pipeline definition in the body of the request.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/query_rules.py
+++ b/elasticsearch_serverless/_async/client/query_rules.py
@@ -38,7 +38,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a query rule within a query ruleset.
+        Delete a query rule. Delete a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html>`_
 
@@ -86,7 +86,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a query ruleset.
+        Delete a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html>`_
 
@@ -127,7 +127,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the details about a query rule within a query ruleset
+        Get a query rule. Get details about a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html>`_
 
@@ -175,7 +175,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the details about a query ruleset
+        Get a query ruleset. Get details about a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html>`_
 
@@ -218,7 +218,7 @@ class QueryRulesClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns summarized information about existing query rulesets.
+        Get all query rulesets. Get summarized information about the query rulesets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html>`_
 
@@ -271,7 +271,7 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query rule within a query ruleset.
+        Create or update a query rule. Create or update a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html>`_
 
@@ -346,7 +346,7 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query ruleset.
+        Create or update a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html>`_
 
@@ -399,7 +399,8 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query ruleset.
+        Test a query ruleset. Evaluate match criteria against a query ruleset to identify
+        the rules that would match that criteria.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-query-ruleset.html>`_
 

--- a/elasticsearch_serverless/_async/client/sql.py
+++ b/elasticsearch_serverless/_async/client/sql.py
@@ -39,7 +39,7 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Clears the SQL cursor
+        Clear an SQL search cursor.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
 
@@ -84,8 +84,8 @@ class SqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes an async SQL search or a stored synchronous SQL search. If the search
-        is still running, the API cancels it.
+        Delete an async SQL search. Delete an async SQL search or a stored synchronous
+        SQL search. If the search is still running, the API cancels it.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
 
@@ -131,8 +131,8 @@ class SqlClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status and available results for an async SQL search or stored
-        synchronous SQL search
+        Get async SQL search results. Get the current status and available results for
+        an async SQL search or stored synchronous SQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
 
@@ -189,8 +189,8 @@ class SqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status of an async SQL search or a stored synchronous SQL
-        search
+        Get the async SQL search status. Get the current status of an async SQL search
+        or a stored synchronous SQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
 
@@ -273,7 +273,7 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes a SQL request
+        Get SQL search results. Run an SQL request.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
 
@@ -383,7 +383,8 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Translates SQL into Elasticsearch queries
+        Translate SQL into Elasticsearch queries. Translate an SQL search into a search
+        API request containing Query DSL.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
 

--- a/elasticsearch_serverless/_async/client/synonyms.py
+++ b/elasticsearch_serverless/_async/client/synonyms.py
@@ -36,7 +36,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a synonym set
+        Delete a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms-set.html>`_
 
@@ -77,7 +77,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a synonym rule in a synonym set
+        Delete a synonym rule. Delete a synonym rule from a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html>`_
 
@@ -127,7 +127,7 @@ class SynonymsClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a synonym set
+        Get a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
 
@@ -174,7 +174,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a synonym rule from a synonym set
+        Get a synonym rule. Get a synonym rule from a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonym-rule.html>`_
 
@@ -223,7 +223,7 @@ class SynonymsClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a summary of all defined synonym sets
+        Get all synonym sets. Get a summary of all defined synonym sets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-synonyms-sets.html>`_
 
@@ -272,7 +272,9 @@ class SynonymsClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a synonym set.
+        Create or update a synonym set. Synonyms sets are limited to a maximum of 10,000
+        synonym rules per set. If you need to manage more synonym rules, you can create
+        multiple synonym sets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html>`_
 
@@ -325,7 +327,8 @@ class SynonymsClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a synonym rule in a synonym set
+        Create or update a synonym rule. Create or update a synonym rule in a synonym
+        set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonym-rule.html>`_
 

--- a/elasticsearch_serverless/_sync/client/__init__.py
+++ b/elasticsearch_serverless/_sync/client/__init__.py
@@ -700,7 +700,7 @@ class Elasticsearch(BaseClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns number of documents matching a query.
+        Count search results. Get the number of documents matching a query.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html>`_
 
@@ -2622,6 +2622,7 @@ class Elasticsearch(BaseClient):
         *,
         index: t.Union[str, t.Sequence[str]],
         keep_alive: t.Union[str, t.Literal[-1], t.Literal[0]],
+        allow_partial_search_results: t.Optional[bool] = None,
         error_trace: t.Optional[bool] = None,
         expand_wildcards: t.Optional[
             t.Union[
@@ -2656,6 +2657,10 @@ class Elasticsearch(BaseClient):
         :param index: A comma-separated list of index names to open point in time; use
             `_all` or empty string to perform the operation on all indices
         :param keep_alive: Extends the time to live of the corresponding point in time.
+        :param allow_partial_search_results: If `false`, creating a point in time request
+            when a shard is missing or unavailable will throw an exception. If `true`,
+            the point in time will contain all the shards that are available at the time
+            of the request.
         :param expand_wildcards: Type of index that wildcard patterns can match. If the
             request can target data streams, this argument determines whether wildcard
             expressions match hidden data streams. Supports comma-separated values, such
@@ -2678,6 +2683,8 @@ class Elasticsearch(BaseClient):
         __body: t.Dict[str, t.Any] = body if body is not None else {}
         if keep_alive is not None:
             __query["keep_alive"] = keep_alive
+        if allow_partial_search_results is not None:
+            __query["allow_partial_search_results"] = allow_partial_search_results
         if error_trace is not None:
             __query["error_trace"] = error_trace
         if expand_wildcards is not None:

--- a/elasticsearch_serverless/_sync/client/async_search.py
+++ b/elasticsearch_serverless/_sync/client/async_search.py
@@ -145,6 +145,7 @@ class AsyncSearchClient(NamespacedClient):
         error_trace: t.Optional[bool] = None,
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
+        keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -156,6 +157,9 @@ class AsyncSearchClient(NamespacedClient):
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/async-search.html>`_
 
         :param id: A unique identifier for the async search.
+        :param keep_alive: Specifies how long the async search needs to be available.
+            Ongoing async searches and any saved search results are deleted after this
+            period.
         """
         if id in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'id'")
@@ -168,6 +172,8 @@ class AsyncSearchClient(NamespacedClient):
             __query["filter_path"] = filter_path
         if human is not None:
             __query["human"] = human
+        if keep_alive is not None:
+            __query["keep_alive"] = keep_alive
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -258,7 +264,6 @@ class AsyncSearchClient(NamespacedClient):
         ignore_throttled: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
         indices_boost: t.Optional[t.Sequence[t.Mapping[str, float]]] = None,
-        keep_alive: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         keep_on_completion: t.Optional[bool] = None,
         knn: t.Optional[
             t.Union[t.Mapping[str, t.Any], t.Sequence[t.Mapping[str, t.Any]]]
@@ -268,7 +273,6 @@ class AsyncSearchClient(NamespacedClient):
         min_score: t.Optional[float] = None,
         pit: t.Optional[t.Mapping[str, t.Any]] = None,
         post_filter: t.Optional[t.Mapping[str, t.Any]] = None,
-        pre_filter_shard_size: t.Optional[int] = None,
         preference: t.Optional[str] = None,
         pretty: t.Optional[bool] = None,
         profile: t.Optional[bool] = None,
@@ -282,7 +286,6 @@ class AsyncSearchClient(NamespacedClient):
         routing: t.Optional[str] = None,
         runtime_mappings: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
         script_fields: t.Optional[t.Mapping[str, t.Mapping[str, t.Any]]] = None,
-        scroll: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         search_after: t.Optional[
             t.Sequence[t.Union[None, bool, float, int, str, t.Any]]
         ] = None,
@@ -375,9 +378,6 @@ class AsyncSearchClient(NamespacedClient):
         :param ignore_unavailable: Whether specified concrete indices should be ignored
             when unavailable (missing or closed)
         :param indices_boost: Boosts the _score of documents from specified indices.
-        :param keep_alive: Specifies how long the async search needs to be available.
-            Ongoing async searches and any saved search results are deleted after this
-            period.
         :param keep_on_completion: If `true`, results are stored for later retrieval
             when the search completes within the `wait_for_completion_timeout`.
         :param knn: Defines the approximate kNN search to run.
@@ -392,10 +392,6 @@ class AsyncSearchClient(NamespacedClient):
         :param pit: Limits the search to a point in time (PIT). If you provide a PIT,
             you cannot specify an <index> in the request path.
         :param post_filter:
-        :param pre_filter_shard_size: The default value cannot be changed, which enforces
-            the execution of a pre-filter roundtrip to retrieve statistics from each
-            shard so that the ones that surely don’t hold any document matching the query
-            get skipped.
         :param preference: Specify the node or shard the operation should be performed
             on (default: random)
         :param profile:
@@ -404,13 +400,13 @@ class AsyncSearchClient(NamespacedClient):
         :param request_cache: Specify if request cache should be used for this request
             or not, defaults to true
         :param rescore:
-        :param rest_total_hits_as_int:
+        :param rest_total_hits_as_int: Indicates whether hits.total should be rendered
+            as an integer or an object in the rest search response
         :param routing: A comma-separated list of specific routing values
         :param runtime_mappings: Defines one or more runtime fields in the search request.
             These fields take precedence over mapped fields with the same name.
         :param script_fields: Retrieve a script evaluation (based on different fields)
             for each hit.
-        :param scroll:
         :param search_after:
         :param search_type: Search operation type
         :param seq_no_primary_term: If true, returns sequence number and primary term
@@ -507,16 +503,12 @@ class AsyncSearchClient(NamespacedClient):
             __query["ignore_throttled"] = ignore_throttled
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
-        if keep_alive is not None:
-            __query["keep_alive"] = keep_alive
         if keep_on_completion is not None:
             __query["keep_on_completion"] = keep_on_completion
         if lenient is not None:
             __query["lenient"] = lenient
         if max_concurrent_shard_requests is not None:
             __query["max_concurrent_shard_requests"] = max_concurrent_shard_requests
-        if pre_filter_shard_size is not None:
-            __query["pre_filter_shard_size"] = pre_filter_shard_size
         if preference is not None:
             __query["preference"] = preference
         if pretty is not None:
@@ -529,8 +521,6 @@ class AsyncSearchClient(NamespacedClient):
             __query["rest_total_hits_as_int"] = rest_total_hits_as_int
         if routing is not None:
             __query["routing"] = routing
-        if scroll is not None:
-            __query["scroll"] = scroll
         if search_type is not None:
             __query["search_type"] = search_type
         if source_excludes is not None:

--- a/elasticsearch_serverless/_sync/client/cat.py
+++ b/elasticsearch_serverless/_sync/client/cat.py
@@ -1551,7 +1551,7 @@ class CatClient(NamespacedClient):
         v: t.Optional[bool] = None,
     ) -> t.Union[ObjectApiResponse[t.Any], TextApiResponse]:
         """
-        Get transforms. Returns configuration and usage information about transforms.
+        Get transform information. Get configuration and usage information about transforms.
         CAT APIs are only intended for human consumption using the Kibana console or
         command line. They are not intended for use by applications. For application
         consumption, use the get transform statistics API.

--- a/elasticsearch_serverless/_sync/client/enrich.py
+++ b/elasticsearch_serverless/_sync/client/enrich.py
@@ -77,7 +77,7 @@ class EnrichClient(NamespacedClient):
         wait_for_completion: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates the enrich index for an existing enrich policy.
+        Run an enrich policy. Create the enrich index for an existing enrich policy.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/execute-enrich-policy-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/eql.py
+++ b/elasticsearch_serverless/_sync/client/eql.py
@@ -36,8 +36,8 @@ class EqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes an async EQL search or a stored synchronous EQL search. The API also
-        deletes results for the search.
+        Delete an async EQL search. Delete an async EQL search or a stored synchronous
+        EQL search. The API also deletes results for the search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 
@@ -83,8 +83,8 @@ class EqlClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status and available results for an async EQL search or a
-        stored synchronous EQL search.
+        Get async EQL search results. Get the current status and available results for
+        an async EQL search or a stored synchronous EQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html>`_
 
@@ -134,8 +134,8 @@ class EqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status for an async EQL search or a stored synchronous EQL
-        search without returning results.
+        Get the async EQL status. Get the current status for an async EQL search or a
+        stored synchronous EQL search without returning results.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-status-api.html>`_
 
@@ -225,7 +225,9 @@ class EqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns results matching a query expressed in Event Query Language (EQL)
+        Get EQL search results. Returns search results for an Event Query Language (EQL)
+        query. EQL assumes each document in a data stream or index corresponds to an
+        event.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-search-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/esql.py
+++ b/elasticsearch_serverless/_sync/client/esql.py
@@ -68,7 +68,8 @@ class EsqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes an ES|QL request
+        Run an ES|QL query. Get search results for an ES|QL (Elasticsearch query language)
+        query.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-rest.html>`_
 

--- a/elasticsearch_serverless/_sync/client/graph.py
+++ b/elasticsearch_serverless/_sync/client/graph.py
@@ -45,8 +45,14 @@ class GraphClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Extracts and summarizes information about the documents and terms in an Elasticsearch
-        data stream or index.
+        Explore graph analytics. Extract and summarize information about the documents
+        and terms in an Elasticsearch data stream or index. The easiest way to understand
+        the behavior of this API is to use the Graph UI to explore connections. An initial
+        request to the `_explore` API contains a seed query that identifies the documents
+        of interest and specifies the fields that define the vertices and connections
+        you want to include in the graph. Subsequent requests enable you to spider out
+        from one more vertices of interest. You can exclude vertices that have already
+        been returned.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/graph-explore-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/indices.py
+++ b/elasticsearch_serverless/_sync/client/indices.py
@@ -701,6 +701,7 @@ class IndicesClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> HeadApiResponse:
         """
@@ -721,6 +722,9 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param ignore_unavailable: If `false`, requests that include a missing data stream
             or index in the target indices or data streams return an error.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         if name in SKIP_IN_PATH:
             raise ValueError("Empty value passed for parameter 'name'")
@@ -746,6 +750,8 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -770,7 +776,7 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> HeadApiResponse:
         """
-        Returns information about whether a particular index template exists.
+        Check index templates. Check whether index templates exist.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html>`_
 
@@ -974,6 +980,7 @@ class IndicesClient(NamespacedClient):
         filter_path: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         human: t.Optional[bool] = None,
         ignore_unavailable: t.Optional[bool] = None,
+        master_timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
@@ -995,6 +1002,9 @@ class IndicesClient(NamespacedClient):
             as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
         :param ignore_unavailable: If `false`, the request returns an error if it targets
             a missing or closed index.
+        :param master_timeout: Period to wait for a connection to the master node. If
+            no response is received before the timeout expires, the request fails and
+            returns an error.
         """
         __path_parts: t.Dict[str, str]
         if index not in SKIP_IN_PATH and name not in SKIP_IN_PATH:
@@ -1022,6 +1032,8 @@ class IndicesClient(NamespacedClient):
             __query["human"] = human
         if ignore_unavailable is not None:
             __query["ignore_unavailable"] = ignore_unavailable
+        if master_timeout is not None:
+            __query["master_timeout"] = master_timeout
         if pretty is not None:
             __query["pretty"] = pretty
         __headers = {"accept": "application/json"}
@@ -2208,8 +2220,8 @@ class IndicesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Resolves the specified name(s) and/or index patterns for indices, aliases, and
-        data streams. Multiple patterns and remote clusters are supported.
+        Resolve indices. Resolve the names and/or index patterns for indices, aliases,
+        and data streams. Multiple patterns and remote clusters are supported.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/inference.py
+++ b/elasticsearch_serverless/_sync/client/inference.py
@@ -20,19 +20,12 @@ import typing as t
 from elastic_transport import ObjectApiResponse
 
 from ._base import NamespacedClient
-from .utils import (
-    SKIP_IN_PATH,
-    Stability,
-    _quote,
-    _rewrite_parameters,
-    _stability_warning,
-)
+from .utils import SKIP_IN_PATH, _quote, _rewrite_parameters
 
 
 class InferenceClient(NamespacedClient):
 
     @_rewrite_parameters()
-    @_stability_warning(Stability.EXPERIMENTAL)
     def delete(
         self,
         *,
@@ -100,7 +93,6 @@ class InferenceClient(NamespacedClient):
         )
 
     @_rewrite_parameters()
-    @_stability_warning(Stability.EXPERIMENTAL)
     def get(
         self,
         *,
@@ -159,7 +151,6 @@ class InferenceClient(NamespacedClient):
     @_rewrite_parameters(
         body_fields=("input", "query", "task_settings"),
     )
-    @_stability_warning(Stability.EXPERIMENTAL)
     def inference(
         self,
         *,
@@ -246,7 +237,6 @@ class InferenceClient(NamespacedClient):
     @_rewrite_parameters(
         body_name="inference_config",
     )
-    @_stability_warning(Stability.EXPERIMENTAL)
     def put(
         self,
         *,

--- a/elasticsearch_serverless/_sync/client/ingest.py
+++ b/elasticsearch_serverless/_sync/client/ingest.py
@@ -38,7 +38,7 @@ class IngestClient(NamespacedClient):
         timeout: t.Optional[t.Union[str, t.Literal[-1], t.Literal[0]]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes one or more existing ingest pipeline.
+        Delete pipelines. Delete one or more ingest pipelines.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html>`_
 
@@ -90,8 +90,8 @@ class IngestClient(NamespacedClient):
         summary: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns information about one or more ingest pipelines. This API returns a local
-        reference of the pipeline.
+        Get pipelines. Get information about one or more ingest pipelines. This API returns
+        a local reference of the pipeline.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html>`_
 
@@ -142,10 +142,10 @@ class IngestClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Extracts structured fields out of a single text field within a document. You
-        choose which field to extract matched fields from, as well as the grok pattern
-        you expect will match. A grok pattern is like a regular expression that supports
-        aliased expressions that can be reused.
+        Run a grok processor. Extract structured fields out of a single text field within
+        a document. You must choose which field to extract matched fields from, as well
+        as the grok pattern you expect will match. A grok pattern is like a regular expression
+        that supports aliased expressions that can be reused.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html>`_
         """
@@ -201,8 +201,7 @@ class IngestClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates an ingest pipeline. Changes made using this API take effect
-        immediately.
+        Create or update a pipeline. Changes made using this API take effect immediately.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html>`_
 
@@ -294,7 +293,9 @@ class IngestClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes an ingest pipeline against a set of provided documents.
+        Simulate a pipeline. Run an ingest pipeline against a set of provided documents.
+        You can either specify an existing pipeline to use with the provided documents
+        or supply a pipeline definition in the body of the request.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/query_rules.py
+++ b/elasticsearch_serverless/_sync/client/query_rules.py
@@ -38,7 +38,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a query rule within a query ruleset.
+        Delete a query rule. Delete a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html>`_
 
@@ -86,7 +86,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a query ruleset.
+        Delete a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html>`_
 
@@ -127,7 +127,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the details about a query rule within a query ruleset
+        Get a query rule. Get details about a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html>`_
 
@@ -175,7 +175,7 @@ class QueryRulesClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the details about a query ruleset
+        Get a query ruleset. Get details about a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html>`_
 
@@ -218,7 +218,7 @@ class QueryRulesClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns summarized information about existing query rulesets.
+        Get all query rulesets. Get summarized information about the query rulesets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html>`_
 
@@ -271,7 +271,7 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query rule within a query ruleset.
+        Create or update a query rule. Create or update a query rule within a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html>`_
 
@@ -346,7 +346,7 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query ruleset.
+        Create or update a query ruleset.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html>`_
 
@@ -399,7 +399,8 @@ class QueryRulesClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a query ruleset.
+        Test a query ruleset. Evaluate match criteria against a query ruleset to identify
+        the rules that would match that criteria.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/test-query-ruleset.html>`_
 

--- a/elasticsearch_serverless/_sync/client/sql.py
+++ b/elasticsearch_serverless/_sync/client/sql.py
@@ -39,7 +39,7 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Clears the SQL cursor
+        Clear an SQL search cursor.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-sql-cursor-api.html>`_
 
@@ -84,8 +84,8 @@ class SqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes an async SQL search or a stored synchronous SQL search. If the search
-        is still running, the API cancels it.
+        Delete an async SQL search. Delete an async SQL search or a stored synchronous
+        SQL search. If the search is still running, the API cancels it.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-async-sql-search-api.html>`_
 
@@ -131,8 +131,8 @@ class SqlClient(NamespacedClient):
         ] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status and available results for an async SQL search or stored
-        synchronous SQL search
+        Get async SQL search results. Get the current status and available results for
+        an async SQL search or stored synchronous SQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-api.html>`_
 
@@ -189,8 +189,8 @@ class SqlClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Returns the current status of an async SQL search or a stored synchronous SQL
-        search
+        Get the async SQL search status. Get the current status of an async SQL search
+        or a stored synchronous SQL search.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-sql-search-status-api.html>`_
 
@@ -273,7 +273,7 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Executes a SQL request
+        Get SQL search results. Run an SQL request.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-search-api.html>`_
 
@@ -383,7 +383,8 @@ class SqlClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Translates SQL into Elasticsearch queries
+        Translate SQL into Elasticsearch queries. Translate an SQL search into a search
+        API request containing Query DSL.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-translate-api.html>`_
 

--- a/elasticsearch_serverless/_sync/client/synonyms.py
+++ b/elasticsearch_serverless/_sync/client/synonyms.py
@@ -36,7 +36,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a synonym set
+        Delete a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms-set.html>`_
 
@@ -77,7 +77,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Deletes a synonym rule in a synonym set
+        Delete a synonym rule. Delete a synonym rule from a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html>`_
 
@@ -127,7 +127,7 @@ class SynonymsClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a synonym set
+        Get a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html>`_
 
@@ -174,7 +174,7 @@ class SynonymsClient(NamespacedClient):
         pretty: t.Optional[bool] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a synonym rule from a synonym set
+        Get a synonym rule. Get a synonym rule from a synonym set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonym-rule.html>`_
 
@@ -223,7 +223,7 @@ class SynonymsClient(NamespacedClient):
         size: t.Optional[int] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Retrieves a summary of all defined synonym sets
+        Get all synonym sets. Get a summary of all defined synonym sets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/list-synonyms-sets.html>`_
 
@@ -272,7 +272,9 @@ class SynonymsClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a synonym set.
+        Create or update a synonym set. Synonyms sets are limited to a maximum of 10,000
+        synonym rules per set. If you need to manage more synonym rules, you can create
+        multiple synonym sets.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html>`_
 
@@ -325,7 +327,8 @@ class SynonymsClient(NamespacedClient):
         body: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> ObjectApiResponse[t.Any]:
         """
-        Creates or updates a synonym rule in a synonym set
+        Create or update a synonym rule. Create or update a synonym rule in a synonym
+        set.
 
         `<https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonym-rule.html>`_
 


### PR DESCRIPTION
* Mark all Inference APIs as stable.
* Add `allow_partial_search_results` to the Open Point in Time API
* Add `keep_alive` to the Get async search status API
* Remove the `keep_alive`, `pre_filter_shard_size` and `scroll` parameters from the Submit async search API. They were never supported.
* Add `master_timeout` to the Alias exists and Get alias APIs.
