### PR TITLE
Ignore more serverless index templates

### DIFF
--- a/test_elasticsearch_serverless/utils.py
+++ b/test_elasticsearch_serverless/utils.py
@@ -132,6 +132,9 @@ def is_xpack_template(name):
     elif "fleet_server" in name:
         return True
     return name in {
+        "agentless",
+        "agentless@mappings",
+        "agentless@settings",
         "apm-10d@lifecycle",
         "apm-180d@lifecycle",
         "apm-390d@lifecycle",


### PR DESCRIPTION
They are currently breaking CI: https://buildkite.com/elastic/elasticsearch-serverless-python-rest-tests/builds/1217#01946cd9-a079-430a-b838-8a0222f21c52